### PR TITLE
Major refactorization and fix schema generation bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ We use [Jest](https://jestjs.io) to implement the tests. In order to test your c
 npm run-script test
 ```
 
+### Lint
+
+After modifying the code execute the following command to pass the linter:
+
+```console
+npm run-script lint
+```
+
 ## Basic usage
 
 ```console

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Readme Generator For Helm
 
 Autogenerate Helm Charts READMEs' tables based on values YAML file metadata.
+Autogenerate an OpenAPI compliant JSON schema defining the `values.yaml` structure of the Helm Chart.
 
 ## How it works
 
@@ -61,10 +62,10 @@ npm run-script test
 Usage: readme-generator [options]
 
 Options:
-  -r, --readme <path>   Path to the README.md file
+  -r, --readme <path>   Path to the README.md file to insert the table
   -v, --values <path>   Path to the values.yaml file
   -c, --config <path>   Path to the config file
-  -m, --metadata <path> Path to the metadata file
+  -m, --metadata <path> Path to a file where to store the metadata
   -h, --help            display help for command
 ```
 

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@
 /* eslint-disable global-require */
 /* eslint-disable import/no-dynamic-require */
 
-const { createValuesObject, parseMetadataComments, generateMetadataObject } = require('./lib/parser');
+const { createValuesObject, parseMetadataComments } = require('./lib/parser');
 const { checkKeys } = require('./lib/checker');
-const { buildSections } = require('./lib/builder');
+const { combineMetadataAndValues, buildSectionsArrays, buildParamsToRenderList } = require('./lib/builder');
 const { insertReadmeTable, exportMetadata } = require('./lib/render');
 
-function getValuesSections(options) {
+function getParameters(options) {
   const valuesFilePath = options.values;
   const configPath = options.config ? options.config : `${__dirname}/config.json`;
   const CONFIG = require(configPath);
@@ -22,10 +22,10 @@ function getValuesSections(options) {
   // Check the parsed keys are consistent with the real ones
   checkKeys(valuesObject, valuesMetadata);
 
-  // We don't need the skip objects anymore so filter them
-  valuesMetadata = valuesMetadata.filter((el) => (!el.skip));
-  // Return sections array combining metadata and real values
-  return buildSections(valuesObject, valuesMetadata);
+  // valuesMetadata is modified and filled with more info
+  combineMetadataAndValues(valuesObject, valuesMetadata);
+
+  return valuesMetadata;
 }
 
 function runReadmeGenerator(options) {
@@ -42,19 +42,19 @@ function runReadmeGenerator(options) {
 
   const configPath = options.config ? options.config : `${__dirname}/config.json`;
   const CONFIG = require(configPath);
-  const sections = getValuesSections(options);
+  const parametersList = getParameters(options);
 
   if (readmeFilePath) {
+    const paramsToRender = buildParamsToRenderList(parametersList, CONFIG);
+    const sections = buildSectionsArrays(paramsToRender);
     insertReadmeTable(readmeFilePath, sections, CONFIG);
   }
 
   if (metadataFilePath) {
-    const metadata = generateMetadataObject(sections, valuesFilePath);
-    exportMetadata(metadataFilePath, metadata);
+    exportMetadata(metadataFilePath, parametersList);
   }
 }
 
 module.exports = {
-  getValuesSections,
   runReadmeGenerator,
 };

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function getParameters(options) {
   // Check the parsed keys are consistent with the real ones
   checkKeys(valuesObject, valuesMetadata);
 
+  // Combine after the check
   // valuesMetadata is modified and filled with more info
   combineMetadataAndValues(valuesObject, valuesMetadata);
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function getParameters(options) {
   const CONFIG = require(configPath);
 
   const valuesObject = createValuesObject(valuesFilePath);
-  let valuesMetadata = parseMetadataComments(valuesFilePath, CONFIG);
+  const valuesMetadata = parseMetadataComments(valuesFilePath, CONFIG);
 
   // Check the parsed keys are consistent with the real ones
   checkKeys(valuesObject, valuesMetadata);

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,73 +3,9 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+/* eslint-disable no-restricted-syntax */
+
 const { groupBy, cloneDeep } = require('lodash');
-
-/* Transform the list of Parameters into an object whose keys are the section names and
-*  their values are the array of parameters for the section
-*  Example:
-*  {
-*    "section1": [{...}, {...}],
-*    "section2": [{...}, {...}]
-*  }
-*/
-function buildSectionsArrays(parameters) {
-  return groupBy(parameters, 'section');
-}
-
-/*
-* Returns the array of Parameters after combining the information from the actual YAML with the parsed from the comments:
-* Params:
-*   - valuesObject: object with the real values built from the YAML.
-*   - valuesMetadata: full metadata object parsed from comments
-* Returns: array of Parameters with all the needed information about them
-* IMPORTANT: the array returned will have fields that should not be rendered on the README and
-*            fields that should not be rendered in the schema. They will be selected later.
-*/
-function combineMetadataAndValues(valuesObject, valuesMetadata) {
-  for (let param of valuesMetadata) {
-    // The parameters with extra do not appear in the actual object and don't have a value, skip them
-    if (!param.extra) {
-      let paramIndex = valuesObject.findIndex((e) => e.name === param.name);
-      if (paramIndex != -1) {
-        // Set the value from actual object
-        param.value = valuesObject[paramIndex].value;
-        param.type = valuesObject[paramIndex].type;
-      }
-    }
-  }
-
-  // Add missing parameters to the metadata.
-  // For example, the skip parameters are not parsed from metadata but must be in the array
-  // to be rendered in the OpenAPI schema
-  for (let param of valuesObject) {
-    let paramIndex = valuesMetadata.findIndex((e) => e.name === param.name);
-    if (paramIndex === -1) {
-      // Find the position of the skip parameter
-      paramIndex = valuesObject.findIndex((e) => e.name.startsWith(param.name));
-      param.skip = true; // Avoid to render it on the READMEs
-      param.forceRenderIntoSchema = true;
-      // Push the parameter after the skip object
-      valuesMetadata.splice(paramIndex + 1, 0, param);
-    }
-  }
-}
-
-/*
-* Returns the list that will be rendered in the README after applying modifiers and filtering params to skip
-*/
-function buildParamsToRenderList(parametersList, config) {
-  let returnList = cloneDeep(parametersList);
-  for (let param of returnList) {
-    if (param.modifier) {
-      param.value = applyModifiers(param.modifier, config);
-    }
-    // The skip parameters must not be rendered in the README
-    returnList = returnList.filter((p) => (!p.skip));
-  }
-
-  return returnList;
-}
 
 /*
  * Returns the proper value for the provided modifier
@@ -90,6 +26,73 @@ function applyModifiers(modifier, config) {
       throw new Error(`Unknown modifier: ${modifier}`);
   }
   return value;
+}
+
+/* Transform the list of Parameters into an object whose keys are the section names and
+*  their values are the array of parameters for the section
+*  Example:
+*  {
+*    "section1": [{...}, {...}],
+*    "section2": [{...}, {...}]
+*  }
+*/
+function buildSectionsArrays(parameters) {
+  return groupBy(parameters, 'section');
+}
+
+/*
+* Returns the array of Parameters after combining the information from the actual YAML with
+* the parsed from the comments:
+* Params:
+*   - valuesObject: object with the real values built from the YAML.
+*   - valuesMetadata: full metadata object parsed from comments
+* Returns: array of Parameters with all the needed information about them
+* IMPORTANT: the array returned will have fields that should not be rendered on the README and
+*            fields that should not be rendered in the schema. They will be selected later.
+*/
+function combineMetadataAndValues(valuesObject, valuesMetadata) {
+  for (const param of valuesMetadata) {
+    // The parameters with extra do not appear in the actual object and don't have a value
+    if (!param.extra) {
+      const paramIndex = valuesObject.findIndex((e) => e.name === param.name);
+      if (paramIndex !== -1) {
+        // Set the value from actual object
+        param.value = valuesObject[paramIndex].value;
+        param.type = valuesObject[paramIndex].type;
+      }
+    }
+  }
+
+  // Add missing parameters to the metadata.
+  // For example, the skip parameters are not parsed from metadata but must be in the array
+  // to be rendered in the OpenAPI schema
+  for (const param of valuesObject) {
+    let paramIndex = valuesMetadata.findIndex((e) => e.name === param.name);
+    if (paramIndex === -1) {
+      // Find the position of the skip parameter
+      paramIndex = valuesObject.findIndex((e) => e.name.startsWith(param.name));
+      param.skip = true; // Avoid to render it on the READMEs
+      param.forceRenderIntoSchema = true;
+      // Push the parameter after the skip object
+      valuesMetadata.splice(paramIndex + 1, 0, param);
+    }
+  }
+}
+
+/*
+* Returns the Parameter list that will be rendered in the README
+*/
+function buildParamsToRenderList(parametersList, config) {
+  let returnList = cloneDeep(parametersList);
+  for (const param of returnList) {
+    if (param.modifier) {
+      param.value = applyModifiers(param.modifier, config);
+    }
+    // The skip parameters must not be rendered in the README
+    returnList = returnList.filter((p) => (!p.skip));
+  }
+
+  return returnList;
 }
 
 module.exports = {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -5,7 +5,8 @@
 
 const { groupBy, cloneDeep } = require('lodash');
 
-/* Transform the list of Parameters into an object whose keys are the section names and their values are the array of section parameters
+/* Transform the list of Parameters into an object whose keys are the section names and
+*  their values are the array of parameters for the section
 *  Example:
 *  {
 *    "section1": [{...}, {...}],
@@ -17,25 +18,19 @@ function buildSectionsArrays(parameters) {
 }
 
 /*
-* Returns the array of Parameters after combining the information with the actual info from the real YAML:
+* Returns the array of Parameters after combining the information from the actual YAML with the parsed from the comments:
 * Params:
 *   - valuesObject: object with the real values built from the YAML.
 *   - valuesMetadata: full metadata object parsed from comments
 * Returns: array of Parameters with all the needed information about them
+* IMPORTANT: the array returned will have fields that should not be rendered on the README and
+*            fields that should not be rendered in the schema. They will be selected later.
 */
 function combineMetadataAndValues(valuesObject, valuesMetadata) {
   for (let param of valuesMetadata) {
-    // The parameters with extra do not appear in the actual object, skip them
+    // The parameters with extra do not appear in the actual object and don't have a value, skip them
     if (!param.extra) {
       let paramIndex = valuesObject.findIndex((e) => e.name === param.name);
-      // If there is not an exact match of the parameter search the one starting with the name,
-      // this has sense when the parameter is an array and the real path contains '[' or
-      // when two parameter's names start with the same, for example: service.port and service.portEnabled
-
-      /*if (paramIndex === -1) {
-        // There is not an exact match, the parameter is an array
-        paramIndex = valuesObject.findIndex((e) => e.name.startsWith(param.name));
-      }*/
       if (paramIndex != -1) {
         // Set the value from actual object
         param.value = valuesObject[paramIndex].value;
@@ -45,7 +40,7 @@ function combineMetadataAndValues(valuesObject, valuesMetadata) {
   }
 
   // Add missing parameters to the metadata.
-  // For example, the skip parameters are not parsed from metadata but must be in the object
+  // For example, the skip parameters are not parsed from metadata but must be in the array
   // to be rendered in the OpenAPI schema
   for (let param of valuesObject) {
     let paramIndex = valuesMetadata.findIndex((e) => e.name === param.name);
@@ -61,7 +56,7 @@ function combineMetadataAndValues(valuesObject, valuesMetadata) {
 }
 
 /*
-* Returns the list that will be rendered after applying modifiers and filtering params to skip
+* Returns the list that will be rendered in the README after applying modifiers and filtering params to skip
 */
 function buildParamsToRenderList(parametersList, config) {
   let returnList = cloneDeep(parametersList);
@@ -69,7 +64,7 @@ function buildParamsToRenderList(parametersList, config) {
     if (param.modifier) {
       param.value = applyModifiers(param.modifier, config);
     }
-    // filter the params with skip
+    // The skip parameters must not be rendered in the README
     returnList = returnList.filter((p) => (!p.skip));
   }
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,53 +3,102 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+const { groupBy, cloneDeep } = require('lodash');
+
+/* Transform the list of Parameters into an object whose keys are the section names and their values are the array of section parameters
+*  Example:
+*  {
+*    "section1": [{...}, {...}],
+*    "section2": [{...}, {...}]
+*  }
+*/
+function buildSectionsArrays(parameters) {
+  return groupBy(parameters, 'section');
+}
+
 /*
-* Build sections of parameters combining real values with parsed metadata and modifiers
+* Returns the array of Parameters after combining the information with the actual info from the real YAML:
 * Params:
 *   - valuesObject: object with the real values built from the YAML.
-*   - valuesMetadata: full metadata object parsed from comments including sections and values
-*                     values can contain modifiers
-* Returns: array of sections' lines, the first line is the section title
+*   - valuesMetadata: full metadata object parsed from comments
+* Returns: array of Parameters with all the needed information about them
 */
-function buildSections(valuesObject, valuesMetadata) {
-  // Insert sections to the final values object
-  const sections = [];
-  valuesMetadata.forEach((obj, i) => {
-    if (obj.section) {
-      const section = [];
-      section.push(obj); // Add section header
-      let nextSectionFound = false;
-      valuesMetadata.slice(i + 1).forEach((param) => {
-        const parameter = { ...param };
-        if (!nextSectionFound && !parameter.section) {
-          if (!parameter.value) {
-            // Find the value in the real values object
-            let paramIndex = valuesObject.findIndex((e) => e.name === parameter.name);
-            // If there is not an exact match of the parameter search the one starting with the name,
-            // this has sense when the parameter is an array and the real path contains '[' or
-            // when two parameter's names start with the same, for example: service.port and service.portEnabled
-            if (paramIndex === -1) {
-              // There is not an exact match, the parameter is an array
-              paramIndex = valuesObject.findIndex((e) => e.name.startsWith(parameter.name));
-            }
-            // Set value from real object if there are not modifiers
-            parameter.value = valuesObject[paramIndex].value;
-          }
-          if (parameter.extra) {
-            parameter.value = '';
-          }
-          section.push(parameter); // Add param to section body
-        } else {
-          nextSectionFound = true;
-        }
-      });
-      sections.push(section);
-    }
-  });
+function combineMetadataAndValues(valuesObject, valuesMetadata) {
+  for (let param of valuesMetadata) {
+    // The parameters with extra do not appear in the actual object, skip them
+    if (!param.extra) {
+      let paramIndex = valuesObject.findIndex((e) => e.name === param.name);
+      // If there is not an exact match of the parameter search the one starting with the name,
+      // this has sense when the parameter is an array and the real path contains '[' or
+      // when two parameter's names start with the same, for example: service.port and service.portEnabled
 
-  return sections;
+      /*if (paramIndex === -1) {
+        // There is not an exact match, the parameter is an array
+        paramIndex = valuesObject.findIndex((e) => e.name.startsWith(param.name));
+      }*/
+      if (paramIndex != -1) {
+        // Set the value from actual object
+        param.value = valuesObject[paramIndex].value;
+        param.type = valuesObject[paramIndex].type;
+      }
+    }
+  }
+
+  // Add missing parameters to the metadata.
+  // For example, the skip parameters are not parsed from metadata but must be in the object
+  // to be rendered in the OpenAPI schema
+  for (let param of valuesObject) {
+    let paramIndex = valuesMetadata.findIndex((e) => e.name === param.name);
+    if (paramIndex === -1) {
+      // Find the position of the skip parameter
+      paramIndex = valuesObject.findIndex((e) => e.name.startsWith(param.name));
+      param.skip = true; // Avoid to render it on the READMEs
+      param.forceRenderIntoSchema = true;
+      // Push the parameter after the skip object
+      valuesMetadata.splice(paramIndex + 1, 0, param);
+    }
+  }
+}
+
+/*
+* Returns the list that will be rendered after applying modifiers and filtering params to skip
+*/
+function buildParamsToRenderList(parametersList, config) {
+  let returnList = cloneDeep(parametersList);
+  for (let param of returnList) {
+    if (param.modifier) {
+      param.value = applyModifiers(param.modifier, config);
+    }
+    // filter the params with skip
+    returnList = returnList.filter((p) => (!p.skip));
+  }
+
+  return returnList;
+}
+
+/*
+ * Returns the proper value for the provided modifier
+ */
+function applyModifiers(modifier, config) {
+  let value;
+  switch (modifier) {
+    case `${config.modifiers.array}`:
+      value = '[]';
+      break;
+    case `${config.modifiers.object}`:
+      value = '{}';
+      break;
+    case `${config.modifiers.string}`:
+      value = '""';
+      break;
+    default:
+      throw new Error(`Unknown modifier: ${modifier}`);
+  }
+  return value;
 }
 
 module.exports = {
-  buildSections,
+  buildSectionsArrays,
+  combineMetadataAndValues,
+  buildParamsToRenderList,
 };

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -3,8 +3,11 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-const utils = require('./utils');
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-console */
+
 const { cloneDeep } = require('lodash');
+const utils = require('./utils');
 
 /*
  * Filter sections and objects
@@ -12,8 +15,7 @@ const { cloneDeep } = require('lodash');
  * @extra entries will skip only its own verification
  */
 function filterValues(valuesObject, valuesMetadata) {
-  /* eslint-disable no-restricted-syntax */
-  const fullMetadataValues =  cloneDeep(valuesMetadata);
+  const fullMetadataValues = cloneDeep(valuesMetadata);
   // Get the values for which we will skip the check
   const valuesToSkip = fullMetadataValues.filter((v) => v.skip || v.modifier);
   const valuesPathToSkip = valuesToSkip.map((v) => {

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -4,6 +4,7 @@
 */
 
 const utils = require('./utils');
+const { cloneDeep } = require('lodash');
 
 /*
  * Filter sections and objects
@@ -12,8 +13,7 @@ const utils = require('./utils');
  */
 function filterValues(valuesObject, valuesMetadata) {
   /* eslint-disable no-restricted-syntax */
-  // Filter sections from parsed values
-  const fullMetadataValues = valuesMetadata.filter((el) => (!el.section));
+  const fullMetadataValues =  cloneDeep(valuesMetadata);
   // Get the values for which we will skip the check
   const valuesToSkip = fullMetadataValues.filter((v) => v.skip || v.modifier);
   const valuesPathToSkip = valuesToSkip.map((v) => {

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -9,19 +9,19 @@ class Parameter {
     this.name = name;
     // The parameter value
     this.value = undefined;
-     // The parameter type
+    // The parameter type
     this.type = '';
-     // The modifier applied to the paramer
+    // The modifier applied to the paramer
     this.modifier = '';
-     // The parameter description
+    // The parameter description
     this.description = '';
-     // The section the parameter belongs to
+    // The section the parameter belongs to
     this.section = '';
-     // Skips the check and README renderization of the parameter
+    // Skips the check and README renderization of the parameter
     this.skip = false;
-     // Extra parameters won't be checked but will be rendered on the README
+    // Extra parameters won't be checked but will be rendered on the README
     this.extra = false;
-     // Force a parameter to appear in the schema. All the actual parameters must go to the schema
+    // Force a parameter to appear in the schema. All the actual parameters must go to the schema
     this.forceRenderIntoSchema = false;
   }
 }

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -5,16 +5,24 @@
 
 class Parameter {
   constructor(name) {
-    this.name = name;                         // The parameter path using dot notation
-    this.value = undefined;                   // The parameter value
-    this.type = "";                           // The parameter type
-    this.modifier = "";                       // The modifier applied to the paramer
-    this.description = "";                    // The parameter description
-    this.section = "";                        // The section the parameter belongs to
-    this.skip = false;                        // Skips the check and README renderization of the parameter
-    this.extra = false;                       // Extra parameters won't be checked but will be rendered on the README
-    this.forceRenderIntoSchema = false;       // Force a parameter to appear in the schema.
-                                              // By default all the actual parameters must go to the schema
+    // The parameter path using dot notation
+    this.name = name;
+    // The parameter value
+    this.value = undefined;
+     // The parameter type
+    this.type = '';
+     // The modifier applied to the paramer
+    this.modifier = '';
+     // The parameter description
+    this.description = '';
+     // The section the parameter belongs to
+    this.section = '';
+     // Skips the check and README renderization of the parameter
+    this.skip = false;
+     // Extra parameters won't be checked but will be rendered on the README
+    this.extra = false;
+     // Force a parameter to appear in the schema. All the actual parameters must go to the schema
+    this.forceRenderIntoSchema = false;
   }
 }
 

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -1,0 +1,46 @@
+/*
+* Copyright 2021-2021 VMware, Inc.
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+class Parameter {
+  constructor(name) {
+    this.name = name;                         // The parameter path using dot notation
+    this.value = undefined;                   // The parameter value
+    this.type = "";                           // The parameter type
+    this._modifier = "";                       // The modifier applied to the paramer
+    this.renderActualValue = true;              // If the actual value of the parameter has to be rendered into the README
+    this.description = "";                    // The parameter description
+    this.section = "";                        // The section the parameter belongs to
+    this._skip = false;                        // Skips the check and renderization of the parameter
+    this.extra = false;                       // If the parameter is an extra parameter
+    this.forceRenderIntoSchema = false;        // Force a parameter to apear in the schema
+  }
+
+  get modifier() {
+    return this._modifier;
+  }
+  set modifier(modifier) {
+    if (modifier) {
+      this.renderActualValue = false; // Add a modifier implies to not render the actual value
+      this._modifier = modifier;
+    } else {
+      this.renderActualValue = true;
+      this._modifier = "";
+    }
+  }
+
+  get skip() {
+    return this._skip;
+  }
+  set skip(skip) {
+    if (skip) {
+      this.renderActualValue = false; // If skip is true the parameter must not be rendered
+    } else {
+      this.renderActualValue = true;
+    }
+    this._skip = skip;
+  }
+}
+
+module.exports = Parameter;

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -8,38 +8,13 @@ class Parameter {
     this.name = name;                         // The parameter path using dot notation
     this.value = undefined;                   // The parameter value
     this.type = "";                           // The parameter type
-    this._modifier = "";                       // The modifier applied to the paramer
-    this.renderActualValue = true;              // If the actual value of the parameter has to be rendered into the README
+    this.modifier = "";                       // The modifier applied to the paramer
     this.description = "";                    // The parameter description
     this.section = "";                        // The section the parameter belongs to
-    this._skip = false;                        // Skips the check and renderization of the parameter
-    this.extra = false;                       // If the parameter is an extra parameter
-    this.forceRenderIntoSchema = false;        // Force a parameter to apear in the schema
-  }
-
-  get modifier() {
-    return this._modifier;
-  }
-  set modifier(modifier) {
-    if (modifier) {
-      this.renderActualValue = false; // Add a modifier implies to not render the actual value
-      this._modifier = modifier;
-    } else {
-      this.renderActualValue = true;
-      this._modifier = "";
-    }
-  }
-
-  get skip() {
-    return this._skip;
-  }
-  set skip(skip) {
-    if (skip) {
-      this.renderActualValue = false; // If skip is true the parameter must not be rendered
-    } else {
-      this.renderActualValue = true;
-    }
-    this._skip = skip;
+    this.skip = false;                        // Skips the check and README renderization of the parameter
+    this.extra = false;                       // Extra parameters won't be checked but will be rendered on the README
+    this.forceRenderIntoSchema = false;       // Force a parameter to appear in the schema.
+                                              // By default all the actual parameters must go to the schema
   }
 }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,42 +9,12 @@ const YAML = require('yaml');
 const _ = require('lodash');
 
 const utils = require('./utils');
+const Parameter = require('./parameter');
 
 /*
- * Returns the proper value for the provided modifier
- */
-function applyModifiers(modifier, config) {
-  let type;
-  switch (modifier) {
-    case `${config.modifiers.array}`:
-      type = '[]';
-      break;
-    case `${config.modifiers.object}`:
-      type = '{}';
-      break;
-    case `${config.modifiers.string}`:
-      type = '""';
-      break;
-    default:
-      type = undefined;
-  }
-  return type;
-}
-
-/*
- * Returns an array of objects containing parameters or sections
+ * Returns an array of Parameters
  * The array is parsed from the comments metadata
- * Parameter object structure:
- * {
- *   name: "name", // This will be the final key
- *   description: "description", // This will contain the description
- *   // Undefined if the value has an actual value. '[]', or '{}' if a modifier is provided.
- *   value: "value
- * }
- * Section object structure:
- * {
- *   section: "Section Title"
- * }
+ * See parameter.js
  */
 function parseMetadataComments(valuesFilePath, config) {
   const data = fs.readFileSync(valuesFilePath, 'UTF-8');
@@ -55,43 +25,46 @@ function parseMetadataComments(valuesFilePath, config) {
   const sectionRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.section}\\s*(.*)$`);
   const skipRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.skip}\\s*(.*)$`);
   const extraRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.extra}\\s*([^\\s]+)\\s*(\\[.*\\])?\\s*(.*)$`);
+
+  let currentSection = ""; // We assume there will always be a section before any parameter. At least one section is required
   lines.forEach((line) => {
     // Parse param line
     const paramMatch = line.match(paramRegex);
     if (paramMatch && paramMatch.length > 0) {
-      parsedValues.push({
-        name: paramMatch[1],
-        value: paramMatch[2] ? applyModifiers(paramMatch[2].split('[')[1].split(']')[0], config) : undefined,
-        modifier: !!paramMatch[2],
-        description: paramMatch[3],
-      });
+      const param = new Parameter(paramMatch[1]);
+      param.modifier = paramMatch[2] ? paramMatch[2].split('[')[1].split(']')[0] : "";
+      param.description = paramMatch[3];
+      param.section = currentSection;
+      parsedValues.push(param);
     }
+
     // Parse section line
     const sectionMatch = line.match(sectionRegex);
     if (sectionMatch && sectionMatch.length > 0) {
-      parsedValues.push({
-        section: sectionMatch[1],
-      });
+      currentSection = sectionMatch[1];
     }
+
     // Parse skip line
     const skipMatch = line.match(skipRegex);
     if (skipMatch && skipMatch.length > 0) {
-      parsedValues.push({
-        name: skipMatch[1],
-        skip: true,
-      });
+      const param = new Parameter(skipMatch[1]);
+      param.skip = true;
+      param.section = currentSection;
+      parsedValues.push(param);
     }
+
     // Parse extra line
     const extraMatch = line.match(extraRegex);
     if (extraMatch && extraMatch.length > 0) {
-      parsedValues.push({
-        name: extraMatch[1],
-        description: extraMatch[3],
-        value: '', // Extra parameters will not have a value, they are used to document parameters that are not the final in the dot notation.
-        extra: true,
-      });
+      const param = new Parameter(extraMatch[1]);
+      param.description = extraMatch[3];
+      param.value = ""; // Set an empty string by default since it won't have a value in the actual YAML
+      param.extra = true;
+      param.section = currentSection;
+      parsedValues.push(param);
     }
   });
+
   return parsedValues;
 }
 
@@ -104,6 +77,7 @@ function parseMetadataComments(valuesFilePath, config) {
  *   value: "value"     // This will be the final value for the key path.
  *                      // If the type is not recognized it will be returned as undefined
  *                      // A modifier can be added to handle such type.
+ *   type: "string"     // The parameter type
  * }
  */
 function createValuesObject(valuesFilePath) {
@@ -112,6 +86,7 @@ function createValuesObject(valuesFilePath) {
 
   for (let valuePath in  dot.dot(valuesJSON)) {
     let value = _.get(valuesJSON, valuePath);
+    let type = typeof value;
 
     // Check if the value is a plain array, an array that only contains strings, those strings should not have metadata.
     const valuePathSplit = valuePath.split('[');
@@ -130,80 +105,31 @@ function createValuesObject(valuesFilePath) {
       }
     }
 
+    // Map the javascript 'null' to golang 'nil'
     if (value === null) {
-      value = 'nil'; // Map the javascript 'null' to golang 'nil'
+      value = 'nil';
     }
 
     // When an element is an object it can be object or array
-    // the stringify prints the empty '{}' or '[]'
     if (typeof value === "object") {
-      value = JSON.stringify(value);
+      if (Array.isArray(value)) {
+        type = "array";
+      }
     }
 
     // The existence check is needed to avoid duplicate plain array keys
     if (!resultValues.find((v) => v.name === valuePath)) {
-      resultValues.push({
-        name: valuePath,
-        value,
-      });
+      const param = new Parameter(valuePath);
+      param.value = value;
+      param.type = type;
+      resultValues.push(param);
     }
   }
+
   return resultValues;
-}
-
-/*
- * Returns an array containing name , value, type, section and description for all the parameters
- * in the values.yaml
- * The result is generated from 'sections' object, which is an array of array,
- * while the type is obtained by parsing the YAML file.
- * If a nil value is detected, this function will throw an error.
- */
-function generateMetadataObject(sections, valuesPath) {
-  const values = YAML.parse(fs.readFileSync(valuesPath, 'utf8'));
-  const res = [];
-
-  sections.forEach((section) => {
-    const sectionHeader = section.shift();
-    section.forEach((value) => {
-      const valueTree = value.name.split('.');
-      let valuesAux = values;
-      valueTree.forEach((key) => {
-        const arrayMatch = key.match(/^(.+)\[(.+)\]$/);
-        if (arrayMatch && arrayMatch.length > 0) {
-          valuesAux = valuesAux[arrayMatch[1]][arrayMatch[2]];
-        } else {
-          valuesAux = valuesAux[key];
-        }
-      });
-      const valueAux = value;
-      valueAux.section = sectionHeader.section;
-      // Fix issue with 'typeof' setting Arrays as objects
-      // Ref: https://stackoverflow.com/questions/12996871/why-does-typeof-array-with-objects-return-object-and-not-array
-      if (Array.isArray(valuesAux)) {
-        valueAux.type = 'array';
-      } else {
-        valueAux.type = typeof valuesAux;
-      }
-      delete valueAux.modifier;
-      res.push(valueAux);
-    });
-  });
-
-  const nilValues = [];
-  res.forEach((value) => {
-    if (value.value === 'nil') {
-      nilValues.push(value.name);
-    }
-  });
-  if (nilValues.length > 0) {
-    throw new Error(`Invalid type 'nil' for the following values: ${nilValues.join(', ')}`);
-  }
-
-  return res;
 }
 
 module.exports = {
   parseMetadataComments,
   createValuesObject,
-  generateMetadataObject,
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -3,6 +3,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+/* eslint-disable no-restricted-syntax */
+
 const dot = require('dot-object');
 const fs = require('fs');
 const YAML = require('yaml');
@@ -17,6 +19,8 @@ const Parameter = require('./parameter');
  * See parameter.js
  */
 function parseMetadataComments(valuesFilePath, config) {
+  /*  eslint-disable prefer-destructuring */
+
   const data = fs.readFileSync(valuesFilePath, 'UTF-8');
   const lines = data.split(/\r?\n/);
 
@@ -26,13 +30,13 @@ function parseMetadataComments(valuesFilePath, config) {
   const skipRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.skip}\\s*(.*)$`);
   const extraRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.extra}\\s*([^\\s]+)\\s*(\\[.*\\])?\\s*(.*)$`);
 
-  let currentSection = ""; // We assume there will always be a section before any parameter. At least one section is required
+  let currentSection = ''; // We assume there will always be a section before any parameter. At least one section is required
   lines.forEach((line) => {
     // Parse param line
     const paramMatch = line.match(paramRegex);
     if (paramMatch && paramMatch.length > 0) {
       const param = new Parameter(paramMatch[1]);
-      param.modifier = paramMatch[2] ? paramMatch[2].split('[')[1].split(']')[0] : "";
+      param.modifier = paramMatch[2] ? paramMatch[2].split('[')[1].split(']')[0] : '';
       param.description = paramMatch[3];
       param.section = currentSection;
       parsedValues.push(param);
@@ -58,7 +62,7 @@ function parseMetadataComments(valuesFilePath, config) {
     if (extraMatch && extraMatch.length > 0) {
       const param = new Parameter(extraMatch[1]);
       param.description = extraMatch[3];
-      param.value = ""; // Set an empty string by default since it won't have a value in the actual YAML
+      param.value = ''; // Set an empty string by default since it won't have a value in the actual YAML
       param.extra = true;
       param.section = currentSection;
       parsedValues.push(param);
@@ -75,46 +79,50 @@ function parseMetadataComments(valuesFilePath, config) {
 function createValuesObject(valuesFilePath) {
   const resultValues = [];
   const valuesJSON = YAML.parse(fs.readFileSync(valuesFilePath, 'utf8'));
+  const dottedFormatProperties = dot.dot(valuesJSON);
 
-  for (let valuePath in  dot.dot(valuesJSON)) {
-    let value = _.get(valuesJSON, valuePath);
-    let type = typeof value;
+  for (let valuePath in dottedFormatProperties) {
+    if (Object.prototype.hasOwnProperty.call(dottedFormatProperties, valuePath)) {
+      let value = _.get(valuesJSON, valuePath);
+      let type = typeof value;
 
-    // Check if the value is a plain array, an array that only contains strings, those strings should not have metadata.
-    const valuePathSplit = valuePath.split('[');
-    if (valuePathSplit.length > 1) {
-      // The value is inside an array
-      const arrayPrefix = utils.getArrayPrefix(valuePath);
-      let isPlainArray = true; // Assume it is plain until we prove the opposite
-      _.get(valuesJSON, arrayPrefix).forEach((e) => {
-        if (typeof e !== "string") {
-           isPlainArray = false;
-         }
-      });
-      if (isPlainArray) {
-        value = _.get(valuesJSON, arrayPrefix);
-        valuePath = arrayPrefix;
+      // Check if the value is a plain array, an array that only contains strings,
+      // those strings should not have metadata, the metadata must exist for the array itself
+      const valuePathSplit = valuePath.split('[');
+      if (valuePathSplit.length > 1) {
+        // The value is inside an array
+        const arrayPrefix = utils.getArrayPrefix(valuePath);
+        let isPlainArray = true; // Assume it is plain until we prove the opposite
+        _.get(valuesJSON, arrayPrefix).forEach((e) => {
+          if (typeof e !== 'string') {
+            isPlainArray = false;
+          }
+        });
+        if (isPlainArray) {
+          value = _.get(valuesJSON, arrayPrefix);
+          valuePath = arrayPrefix;
+        }
       }
-    }
 
-    // Map the javascript 'null' to golang 'nil'
-    if (value === null) {
-      value = 'nil';
-    }
-
-    // When an element is an object it can be object or array
-    if (typeof value === "object") {
-      if (Array.isArray(value)) {
-        type = "array";
+      // Map the javascript 'null' to golang 'nil'
+      if (value === null) {
+        value = 'nil';
       }
-    }
 
-    // The existence check is needed to avoid duplicate plain array keys
-    if (!resultValues.find((v) => v.name === valuePath)) {
-      const param = new Parameter(valuePath);
-      param.value = value;
-      param.type = type;
-      resultValues.push(param);
+      // When an element is an object it can be object or array
+      if (typeof value === 'object') {
+        if (Array.isArray(value)) {
+          type = 'array';
+        }
+      }
+
+      // The existence check is needed to avoid duplicate plain array keys
+      if (!resultValues.find((v) => v.name === valuePath)) {
+        const param = new Parameter(valuePath);
+        param.value = value;
+        param.type = type;
+        resultValues.push(param);
+      }
     }
   }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -69,16 +69,8 @@ function parseMetadataComments(valuesFilePath, config) {
 }
 
 /*
- * Returns an array of arrays containing name and value for all the parameters
- * in the values.yaml
- * The array is generated from the YAML keys and values directly
- * {
- *   name: "name",      // This will be a path to the value like a.b.c
- *   value: "value"     // This will be the final value for the key path.
- *                      // If the type is not recognized it will be returned as undefined
- *                      // A modifier can be added to handle such type.
- *   type: "string"     // The parameter type
- * }
+ * Returns an array of Parameters parsed from the actual YAML content
+ * This object contains the actual type and value of the object
  */
 function createValuesObject(valuesFilePath) {
   const resultValues = [];
@@ -95,7 +87,7 @@ function createValuesObject(valuesFilePath) {
       const arrayPrefix = utils.getArrayPrefix(valuePath);
       let isPlainArray = true; // Assume it is plain until we prove the opposite
       _.get(valuesJSON, arrayPrefix).forEach((e) => {
-        if (!(typeof e === "string")) {
+        if (typeof e !== "string") {
            isPlainArray = false;
          }
       });

--- a/lib/render.js
+++ b/lib/render.js
@@ -123,7 +123,6 @@ function generateSchema(value, tree, properties, ignoreDefault = false) {
     if (i === tree.length - 1) {
       properties[tree[i]] = {
         type: value.type,
-        default: undefined, // TODO(miguelaeh): delete this line, it is just to check easier with git diff
         description: value.description,
       };
       if (!ignoreDefault) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const table = require('markdown-table');
+const { cloneDeep } = require('lodash');
 
 /*
  * Converts an array of objects of the same type to markdown table
@@ -14,9 +15,13 @@ function createMarkdownTable(objArray) {
     if (e.value === '') {
       e.value = '""';
     }
+    if (typeof e.value === "object") {
+      // the stringify prints the string '{}' or '[]'
+      e.value = JSON.stringify(e.value);
+    }
     return [`\`${e.name}\``, e.description, e.extra ? '' : `\`${e.value}\``];
   });
-  // return CliPrettify.prettify((toTable(modifiedArray, ['name', 'description', 'value'])));
+
   return table([
     ['Name', 'Description', 'Value'],
     ...modifiedArray,
@@ -26,11 +31,11 @@ function createMarkdownTable(objArray) {
 /*
  * Returns the section rendered
  */
-function renderSection(section, lineNumberSigns) {
+function renderSection(name, values, lineNumberSigns) {
   let sectionTable = '';
   sectionTable += '\r\n';
-  sectionTable += `${lineNumberSigns} ${section[0].section}\r\n\n`; // section header
-  sectionTable += createMarkdownTable(section.slice(1)); // section body parameters
+  sectionTable += `${lineNumberSigns} ${name}\r\n\n`; // section header
+  sectionTable += createMarkdownTable(values); // section body parameters
   sectionTable += '\r\n\n';
   return sectionTable;
 }
@@ -40,105 +45,10 @@ function renderSection(section, lineNumberSigns) {
  */
 function renderReadmeTable(sections, lineNumberSigns) {
   let fullTable = '';
-  sections.forEach((section) => {
-    fullTable += renderSection(section, lineNumberSigns);
-  });
-  return fullTable;
-}
-
-/*
- * Updates the Schema of an object
- * Inputs:
- *  - value: Value that we are generating the schema for. Includes: 'type', 'description', and 'value'.
- *  - tree: Array containing the Value dict tree. For example "global.sample" => ["global", "sample"].
- *  - properties: Schema object properties that will be update. Ref: https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schema-object
- *  - ignoreDefault: If true, the Value default is ignored.
- */
-function generateSchema(value, tree, properties, ignoreDefault = false) {
-  let propertiesAux = properties;
-  // Write schema for the value tree.
-  for (let i = 0; i < tree.length; i += 1) {
-    // If it is the last component of the tree, write its type and default value
-    if (i === tree.length - 1) {
-      propertiesAux[tree[i]] = {
-        type: value.type,
-        default: value.value,
-        description: value.description,
-      };
-      if (ignoreDefault) {
-        delete propertiesAux[tree[i]].default;
-      }
-    } else {
-      // This is required to handle 'Array of objects' values, like extraEnvVars[0].name and extraEnvVars[0].value.
-      // These values are instead stored in an Array type with items.
-      let isArray = false;
-      const arrayMatch = tree[i].match(/^(.+)\[.+\]$/);
-      let key;
-      if (arrayMatch && arrayMatch.length > 0) {
-        /* eslint-disable prefer-destructuring */
-        key = arrayMatch[1];
-        isArray = true;
-      } else {
-        key = tree[i];
-      }
-      if (isArray) {
-        if (!Object.prototype.hasOwnProperty.call(propertiesAux, key)) {
-          // Defines Array schema for "extraEnvVars"
-          propertiesAux[key] = {
-            type: 'array',
-            description: value.description,
-            items: {
-              type: 'object',
-              properties: {},
-            },
-          };
-        }
-        // Creates the schema for the items in the array. Items defaults are ignored.
-        generateSchema(value, tree.splice(i + 1), propertiesAux[key].items.properties, true);
-        // Break the loop, as the array of objects is the last component.
-        break;
-      // If it is not an array and the value didn't exists, adds another block to the chain.
-      } else if (!Object.prototype.hasOwnProperty.call(propertiesAux, key)) {
-        propertiesAux[key] = {
-          type: 'object',
-          properties: {},
-        };
-      }
-      // Updates the propertiesAux for the next tree component
-      propertiesAux = propertiesAux[key].properties;
-    }
+  for (const [sectionName, sectionValues] of Object.entries(sections)) {
+    fullTable += renderSection(sectionName, sectionValues, lineNumberSigns);
   }
-}
-
-/*
- * Creates a Values Schema using the OpenAPIv3 specification.
- * Ref: https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schema-object
- */
-
-function createValuesSchema(values) {
-  const schema = {
-    title: 'Chart Values',
-    type: 'object',
-    properties: {},
-  };
-
-  values.forEach((value) => {
-    const tree = value.name.split('.');
-    if (!value.extra) {
-      // Generate the schema for non extra values
-      generateSchema(value, tree, schema.properties);
-    }
-  });
-  return schema;
-}
-
-/*
- * Export metadata as JSON.
- */
-function exportMetadata(metadataPath, metadataObject) {
-  const schema = createValuesSchema(metadataObject);
-
-  fs.writeFileSync(metadataPath, JSON.stringify(schema, null, 4));
+  return fullTable;
 }
 
 /*
@@ -191,6 +101,120 @@ function insertReadmeTable(readmeFilePath, sections, config) {
   lines.splice(paramsSectionLimits[0] + 1, 0, ...newParamsSection.split(/\r?\n/));
 
   fs.writeFileSync(readmeFilePath, lines.join('\n'));
+}
+
+/*
+ * Updates the Schema of an object
+ * Inputs:
+ *  - value: value that we are generating the schema for. Includes: 'type', 'description', and 'value'.
+ *  - tree: Array containing the value dict tree. For example "global.sample" => ["global", "sample"].
+ *  - properties: Schema object properties that will be updated. Ref: https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schema-object
+ *  - ignoreDefault: If true, the default property is ignored.
+ */
+function generateSchema(value, tree, properties, ignoreDefault = false) {
+  // Write schema for the value tree.
+  console.log(value)
+  for (let i = 0; i < tree.length; i += 1) {
+    // If it is the last component of the tree, write its type and default value
+    if (i === tree.length - 1) {
+      properties[tree[i]] = {
+        type: value.type,
+        default: undefined, // TODO(miguelaeh): delete this line, it is just to check easier with git diff
+        description: value.description,
+      };
+
+      if (!ignoreDefault) {
+        properties[tree[i]].default = value.value;
+      }
+    } else {
+      // This is required to handle 'Array of objects' values, like extraEnvVars[0].name and extraEnvVars[0].value.
+      // These values are instead stored in an Array type with items.
+      let isArray = false;
+      const arrayMatch = tree[i].match(/^(.+)\[.+\]$/);
+      let key;
+      if (arrayMatch && arrayMatch.length > 0) {
+        /* eslint-disable prefer-destructuring */
+        key = arrayMatch[1];
+        isArray = true;
+      } else {
+        key = tree[i];
+      }
+      if (isArray) {
+        if (!Object.prototype.hasOwnProperty.call(properties, key)) {
+          // Defines Array schema for "extraEnvVars"
+          properties[key] = {
+            type: 'array',
+            description: value.description,
+            items: {
+              type: 'object',
+              properties: {},
+            },
+          };
+        }
+        // Creates the schema for the items in the array. Items defaults are ignored.
+        generateSchema(value, tree.splice(i + 1), properties[key].items.properties, true);
+        // Break the loop, as the array of objects is the last component.
+        break;
+      // If it is not an array and the value didn't exists, adds another block to the chain.
+      } else if (!Object.prototype.hasOwnProperty.call(properties, key)) {
+        properties[key] = {
+          type: 'object',
+          properties: {},
+        };
+      }
+      // Updates the properties for the next tree component
+      properties = properties[key].properties;
+    }
+  }
+}
+
+/*
+ * Creates a Values Schema using the OpenAPIv3 specification.
+ * Ref: https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schema-object
+ */
+
+function createValuesSchema(values) {
+  const schema = {
+    title: 'Chart Values',
+    type: 'object',
+    properties: {},
+  };
+
+  values.forEach((value) => {
+    const tree = value.name.split('.');
+    generateSchema(value, tree, schema.properties);
+  });
+  return schema;
+}
+
+/*
+ * Export metadata as JSON.
+ */
+function exportMetadata(metadataFilePath, parametersList) {
+  let paramsList = cloneDeep(parametersList);
+  // Find nil values in the between the parameters.
+  const nilValues = paramsList.filter((p) => p.value === 'nil').map((p) => p.name);
+  if (nilValues.length > 0) {
+    throw new Error(`Invalid type 'nil' for the following values: ${nilValues.join(', ')}`);
+  }
+
+  // Filter extra parameters since they are not actually in the YAML object
+  paramsList = paramsList.filter((p) => !p.extra);
+  // The parameters with the "object" modifier should not end in the OpenAPI schema, instead, the actual object should
+  // For example:
+  // @param a.b [object] Whatever
+  // a:
+  //   b: "something"
+  // "a.b" must be in the schema, while "a" is not an actual entry. "a" will be renderer in the README only
+  paramsList = paramsList.filter((p) => p.modifier !== 'object');
+  // If a parameter has "skip" but does not have "forceRenderIntoSchema" to true, it should be removed
+  // Check the combineMetadataAndValues function
+  // This render the schema when setting skip in a final YAML node and does not render the schema
+  // if it is an artificial parameter that comes from setting skip in a intermediate YAML node
+  paramsList = paramsList.filter((p) => !(p.skip && !p.forceRenderIntoSchema));
+
+  const schema = createValuesSchema(paramsList);
+  fs.writeFileSync(metadataFilePath, JSON.stringify(schema, null, 4));
 }
 
 module.exports = {

--- a/lib/render.js
+++ b/lib/render.js
@@ -113,7 +113,6 @@ function insertReadmeTable(readmeFilePath, sections, config) {
  */
 function generateSchema(value, tree, properties, ignoreDefault = false) {
   // Write schema for the value tree.
-  console.log(value)
   for (let i = 0; i < tree.length; i += 1) {
     // If it is the last component of the tree, write its type and default value
     if (i === tree.length - 1) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -3,6 +3,8 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
+/* eslint-disable no-console */
+
 const fs = require('fs');
 const table = require('markdown-table');
 const { cloneDeep } = require('lodash');
@@ -15,7 +17,7 @@ function createMarkdownTable(objArray) {
     if (e.value === '') {
       e.value = '""';
     }
-    if (typeof e.value === "object") {
+    if (typeof e.value === 'object') {
       // the stringify prints the string '{}' or '[]'
       e.value = JSON.stringify(e.value);
     }
@@ -45,6 +47,7 @@ function renderSection(name, values, lineNumberSigns) {
  */
 function renderReadmeTable(sections, lineNumberSigns) {
   let fullTable = '';
+  /* eslint-disable no-restricted-syntax */
   for (const [sectionName, sectionValues] of Object.entries(sections)) {
     fullTable += renderSection(sectionName, sectionValues, lineNumberSigns);
   }
@@ -106,12 +109,14 @@ function insertReadmeTable(readmeFilePath, sections, config) {
 /*
  * Updates the Schema of an object
  * Inputs:
- *  - value: value that we are generating the schema for. Includes: 'type', 'description', and 'value'.
- *  - tree: Array containing the value dict tree. For example "global.sample" => ["global", "sample"].
- *  - properties: Schema object properties that will be updated. Ref: https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schema-object
+ *  - value: Parameter containing: 'type', 'description', and 'value'.
+ *  - tree: Array containing the value dict tree. E.g: "a.b" => ["a", "b"].
+ *  - properties: Schema object properties that will be updated.
+ *    Ref: https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schema-object
  *  - ignoreDefault: If true, the default property is ignored.
  */
 function generateSchema(value, tree, properties, ignoreDefault = false) {
+  /* eslint-disable no-param-reassign */
   // Write schema for the value tree.
   for (let i = 0; i < tree.length; i += 1) {
     // If it is the last component of the tree, write its type and default value
@@ -121,12 +126,11 @@ function generateSchema(value, tree, properties, ignoreDefault = false) {
         default: undefined, // TODO(miguelaeh): delete this line, it is just to check easier with git diff
         description: value.description,
       };
-
       if (!ignoreDefault) {
         properties[tree[i]].default = value.value;
       }
     } else {
-      // This is required to handle 'Array of objects' values, like extraEnvVars[0].name and extraEnvVars[0].value.
+      // This is required to handle 'Array of objects' values, like a[0].b
       // These values are instead stored in an Array type with items.
       let isArray = false;
       const arrayMatch = tree[i].match(/^(.+)\[.+\]$/);
@@ -199,14 +203,14 @@ function exportMetadata(metadataFilePath, parametersList) {
 
   // Filter extra parameters since they are not actually in the YAML object
   paramsList = paramsList.filter((p) => !p.extra);
-  // The parameters with the "object" modifier should not end in the OpenAPI schema, instead, the actual object should
+  // The parameters with the "object" modifier must not end in the schema, the actual object should
   // For example:
   // @param a.b [object] Whatever
   // a:
   //   b: "something"
-  // "a.b" must be in the schema, while "a" is not an actual entry. "a" will be renderer in the README only
+  // "a.b" must be in the schema, while "a" is not an actual entry (Rendered in the README only)
   paramsList = paramsList.filter((p) => p.modifier !== 'object');
-  // If a parameter has "skip" but does not have "forceRenderIntoSchema" to true, it should be removed
+  // If a parameter has "skip" but does not have "forceRenderIntoSchema" to true, remove it
   // Check the combineMetadataAndValues function
   // This render the schema when setting skip in a final YAML node and does not render the schema
   // if it is an artificial parameter that comes from setting skip in a intermediate YAML node

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,7 +15,8 @@ function getArrayPrefix(array) {
 }
 
 /*
- * Returns a dot notation sanitized property name, and in case it is an array the base of the array name without the index
+ * Returns a dot notation sanitized property name
+ * in case it is an array the base of the array name without the index
  * Example:
  *  someArray[0] -> someArray
  *  someArray[0].nested[0] -> someArray[0].nested
@@ -25,9 +26,8 @@ function sanitizeProperty(property) {
   const splitted = property.split('[');
   if (splitted.length > 1) {
     return getArrayPrefix(property);
-  } else {
-    return property;
   }
+  return property;
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Autogenerate READMEs' tables for Bitnami Helm Charts",
   "main": "index.js",
   "scripts": {
-    "test": "npx jest"
+    "test": "npx jest",
+    "lint": "./node_modules/eslint/bin/eslint.js ."
   },
   "bin": {
     "readme-generator": "./bin/index.js"

--- a/tests/expected-metadata.json
+++ b/tests/expected-metadata.json
@@ -7,73 +7,73 @@
             "properties": {
                 "imageRegistry": {
                     "type": "string",
-                    "default": "",
-                    "description": "Global Docker image registry"
+                    "description": "Global Docker image registry",
+                    "default": ""
                 },
                 "imagePullSecrets": {
                     "type": "array",
-                    "default": [],
-                    "description": "Global Docker registry secret names as an array"
+                    "description": "Global Docker registry secret names as an array",
+                    "default": []
                 }
             }
         },
         "nameOverride": {
             "type": "string",
-            "default": "",
-            "description": "String to partially override common.names.fullname"
+            "description": "String to partially override common.names.fullname",
+            "default": ""
         },
         "fullnameOverride": {
             "type": "string",
-            "default": "",
-            "description": "String to fully override common.names.fullname"
+            "description": "String to fully override common.names.fullname",
+            "default": ""
         },
         "commonLabels": {
             "type": "object",
-            "default": {},
-            "description": "Labels to add to all deployed objects"
+            "description": "Labels to add to all deployed objects",
+            "default": {}
         },
         "commonAnnotations": {
             "type": "object",
-            "default": {},
-            "description": "Annotations to add to all deployed objects"
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
         },
         "extraDeploy": {
             "type": "array",
-            "default": [],
-            "description": "Array of extra objects to deploy with the release"
+            "description": "Array of extra objects to deploy with the release",
+            "default": []
         },
         "hostAliases": {
             "type": "array",
-            "default": [],
-            "description": "Add deployment host aliases"
+            "description": "Add deployment host aliases",
+            "default": []
         },
         "image": {
             "type": "object",
             "properties": {
                 "registry": {
                     "type": "string",
-                    "default": "docker.io",
-                    "description": "Kubewatch image registry"
+                    "description": "Kubewatch image registry",
+                    "default": "docker.io"
                 },
                 "repository": {
                     "type": "string",
-                    "default": "bitnami/kubewatch",
-                    "description": "Kubewatch image name"
+                    "description": "Kubewatch image name",
+                    "default": "bitnami/kubewatch"
                 },
                 "tag": {
                     "type": "string",
-                    "default": "0.1.0-debian-10-r162",
-                    "description": "Kubewatch image tag"
+                    "description": "Kubewatch image tag",
+                    "default": "0.1.0-debian-10-r162"
                 },
                 "pullPolicy": {
                     "type": "string",
-                    "default": "IfNotPresent",
-                    "description": "Kubewatch image tag"
+                    "description": "Kubewatch image tag",
+                    "default": "IfNotPresent"
                 },
                 "pullSecrets": {
                     "type": "array",
-                    "default": [],
-                    "description": "Specify docker-registry secret names as an array"
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": []
                 }
             }
         },
@@ -82,18 +82,18 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Enable Slack notifications"
+                    "description": "Enable Slack notifications",
+                    "default": true
                 },
                 "channel": {
                     "type": "string",
-                    "default": "XXXX",
-                    "description": "Slack channel to notify"
+                    "description": "Slack channel to notify",
+                    "default": "XXXX"
                 },
                 "token": {
                     "type": "string",
-                    "default": "XXXX",
-                    "description": "Slack API token"
+                    "description": "Slack API token",
+                    "default": "XXXX"
                 }
             }
         },
@@ -102,23 +102,23 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable HipChat notifications"
+                    "description": "Enable HipChat notifications",
+                    "default": false
                 },
                 "room": {
                     "type": "string",
-                    "default": "",
-                    "description": "HipChat room to notify"
+                    "description": "HipChat room to notify",
+                    "default": ""
                 },
                 "token": {
                     "type": "string",
-                    "default": "",
-                    "description": "HipChat token"
+                    "description": "HipChat token",
+                    "default": ""
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": "HipChat URL"
+                    "description": "HipChat URL",
+                    "default": ""
                 }
             }
         },
@@ -127,23 +127,23 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable Mattermost notifications"
+                    "description": "Enable Mattermost notifications",
+                    "default": false
                 },
                 "channel": {
                     "type": "string",
-                    "default": "",
-                    "description": "Mattermost channel to notify"
+                    "description": "Mattermost channel to notify",
+                    "default": ""
                 },
                 "username": {
                     "type": "string",
-                    "default": "",
-                    "description": "Mattermost user to notify"
+                    "description": "Mattermost user to notify",
+                    "default": ""
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": "Mattermost URL"
+                    "description": "Mattermost URL",
+                    "default": ""
                 }
             }
         },
@@ -152,13 +152,13 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable Flock notifications"
+                    "description": "Enable Flock notifications",
+                    "default": false
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": "Flock URL"
+                    "description": "Flock URL",
+                    "default": ""
                 }
             }
         },
@@ -167,13 +167,13 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable Microsoft Teams notifications"
+                    "description": "Enable Microsoft Teams notifications",
+                    "default": false
                 },
                 "webhookurl": {
                     "type": "string",
-                    "default": "",
-                    "description": "Microsoft Teams webhook URL"
+                    "description": "Microsoft Teams webhook URL",
+                    "default": ""
                 }
             }
         },
@@ -182,13 +182,13 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": ""
+                    "description": "",
+                    "default": false
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": ""
+                    "description": "",
+                    "default": ""
                 }
             }
         },
@@ -197,61 +197,61 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable SMTP (email) notifications"
+                    "description": "Enable SMTP (email) notifications",
+                    "default": false
                 },
                 "to": {
                     "type": "string",
-                    "default": "",
-                    "description": "Destination email address (required)"
+                    "description": "Destination email address (required)",
+                    "default": ""
                 },
                 "from": {
                     "type": "string",
-                    "default": "",
-                    "description": "Source email address (required)"
+                    "description": "Source email address (required)",
+                    "default": ""
                 },
                 "hello": {
                     "type": "string",
-                    "default": "",
-                    "description": "SMTP hello field (optional)"
+                    "description": "SMTP hello field (optional)",
+                    "default": ""
                 },
                 "smarthost": {
                     "type": "string",
-                    "default": "",
-                    "description": "SMTP server address (name:port) (required)"
+                    "description": "SMTP server address (name:port) (required)",
+                    "default": ""
                 },
                 "subject": {
                     "type": "string",
-                    "default": "",
-                    "description": "SMTP subject for the email"
+                    "description": "SMTP subject for the email",
+                    "default": ""
                 },
                 "requireTLS": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Force STARTTLS"
+                    "description": "Force STARTTLS",
+                    "default": false
                 },
                 "auth": {
                     "type": "object",
                     "properties": {
                         "username": {
                             "type": "string",
-                            "default": "",
-                            "description": "Username for LOGIN and PLAIN auth mech"
+                            "description": "Username for LOGIN and PLAIN auth mech",
+                            "default": ""
                         },
                         "password": {
                             "type": "string",
-                            "default": "",
-                            "description": "Password for LOGIN and PLAIN auth mech"
+                            "description": "Password for LOGIN and PLAIN auth mech",
+                            "default": ""
                         },
                         "secret": {
                             "type": "string",
-                            "default": "",
-                            "description": "Secret for CRAM-MD5 auth mech"
+                            "description": "Secret for CRAM-MD5 auth mech",
+                            "default": ""
                         },
                         "identity": {
                             "type": "string",
-                            "default": "",
-                            "description": "Identity for PLAIN auth mech"
+                            "description": "Identity for PLAIN auth mech",
+                            "default": ""
                         }
                     }
                 }
@@ -259,63 +259,63 @@
         },
         "namespaceToWatch": {
             "type": "string",
-            "default": "",
-            "description": "Namespace to watch, leave it empty for watching all"
+            "description": "Namespace to watch, leave it empty for watching all",
+            "default": ""
         },
         "resourcesToWatch": {
             "type": "object",
             "properties": {
                 "pod": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Watch changes to Pods"
+                    "description": "Watch changes to Pods",
+                    "default": true
                 },
                 "deployment": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Watch changes to Deployments"
+                    "description": "Watch changes to Deployments",
+                    "default": true
                 },
                 "replicationcontroller": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to ReplicationControllers"
+                    "description": "Watch changes to ReplicationControllers",
+                    "default": false
                 },
                 "replicaset": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to ReplicaSets"
+                    "description": "Watch changes to ReplicaSets",
+                    "default": false
                 },
                 "daemonset": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to DaemonSets"
+                    "description": "Watch changes to DaemonSets",
+                    "default": false
                 },
                 "services": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to Services"
+                    "description": "Watch changes to Services",
+                    "default": false
                 },
                 "job": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to Jobs"
+                    "description": "Watch changes to Jobs",
+                    "default": false
                 },
                 "persistentvolume": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to PersistentVolumes"
+                    "description": "Watch changes to PersistentVolumes",
+                    "default": false
                 }
             }
         },
         "command": {
             "type": "array",
-            "default": [],
-            "description": "Override default container command (useful when using custom images)"
+            "description": "Override default container command (useful when using custom images)",
+            "default": []
         },
         "args": {
             "type": "array",
-            "default": [],
-            "description": "Override default container args (useful when using custom images)"
+            "description": "Override default container args (useful when using custom images)",
+            "default": []
         },
         "extraEnvVars": {
             "type": "array",
@@ -336,31 +336,31 @@
         },
         "extraEnvVarsCM": {
             "type": "string",
-            "default": "",
-            "description": "Name of existing ConfigMap containing extra env vars"
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
         },
         "extraEnvVarsSecret": {
             "type": "string",
-            "default": "",
-            "description": "Name of existing Secret containing extra env vars"
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
         },
         "replicaCount": {
             "type": "number",
-            "default": 1,
-            "description": "Number of Kubewatch replicas to deploy"
+            "description": "Number of Kubewatch replicas to deploy",
+            "default": 1
         },
         "podSecurityContext": {
             "type": "object",
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enabled Kubewatch pods' Security Context"
+                    "description": "Enabled Kubewatch pods' Security Context",
+                    "default": false
                 },
                 "fsGroup": {
                     "type": "number",
-                    "default": 1001,
-                    "description": "Set Kubewatch pod's Security Context fsGroup"
+                    "description": "Set Kubewatch pod's Security Context fsGroup",
+                    "default": 1001
                 }
             }
         },
@@ -369,18 +369,18 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enabled Kubewatch containers' Security Context"
+                    "description": "Enabled Kubewatch containers' Security Context",
+                    "default": false
                 },
                 "runAsUser": {
                     "type": "number",
-                    "default": 1001,
-                    "description": "Set Kubewatch container's Security Context runAsUser"
+                    "description": "Set Kubewatch container's Security Context runAsUser",
+                    "default": 1001
                 },
                 "runAsNonRoot": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Set Kubewatch container's Security Context runAsNonRoot"
+                    "description": "Set Kubewatch container's Security Context runAsNonRoot",
+                    "default": true
                 }
             }
         },
@@ -389,13 +389,13 @@
             "properties": {
                 "limits": {
                     "type": "object",
-                    "default": {},
-                    "description": ""
+                    "description": "",
+                    "default": {}
                 },
                 "requests": {
                     "type": "object",
-                    "default": {},
-                    "description": ""
+                    "description": "",
+                    "default": {}
                 }
             }
         },
@@ -404,33 +404,33 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable livenessProbe"
+                    "description": "Enable livenessProbe",
+                    "default": false
                 },
                 "initialDelaySeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Initial delay seconds for livenessProbe"
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
                 },
                 "periodSeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Period seconds for livenessProbe"
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
                 },
                 "timeoutSeconds": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Timeout seconds for livenessProbe"
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
                 },
                 "failureThreshold": {
                     "type": "number",
-                    "default": 3,
-                    "description": "Failure threshold for livenessProbe"
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
                 },
                 "successThreshold": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Success threshold for livenessProbe"
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
                 }
             }
         },
@@ -439,128 +439,128 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable readinessProbe"
+                    "description": "Enable readinessProbe",
+                    "default": false
                 },
                 "initialDelaySeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Initial delay seconds for readinessProbe"
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
                 },
                 "periodSeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Period seconds for readinessProbe"
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
                 },
                 "timeoutSeconds": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Timeout seconds for readinessProbe"
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
                 },
                 "failureThreshold": {
                     "type": "number",
-                    "default": 3,
-                    "description": "Failure threshold for readinessProbe"
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
                 },
                 "successThreshold": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Success threshold for readinessProbe"
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
                 }
             }
         },
         "customLivenessProbe": {
             "type": "object",
-            "default": {},
-            "description": "Override default liveness probe"
+            "description": "Override default liveness probe",
+            "default": {}
         },
         "customReadinessProbe": {
             "type": "object",
-            "default": {},
-            "description": "Override default readiness probe"
+            "description": "Override default readiness probe",
+            "default": {}
         },
         "podAffinityPreset": {
             "type": "string",
-            "default": "",
-            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`"
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
         },
         "podAntiAffinityPreset": {
             "type": "string",
-            "default": "soft",
-            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`"
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
         },
         "nodeAffinityPreset": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "default": "",
-                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`"
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
                 },
                 "key": {
                     "type": "string",
-                    "default": "",
-                    "description": "Node label key to match. Ignored if `affinity` is set"
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
                 },
                 "values": {
                     "type": "array",
-                    "default": [],
-                    "description": "Node label values to match. Ignored if `affinity` is set"
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": []
                 }
             }
         },
         "affinity": {
             "type": "object",
-            "default": {},
-            "description": "Affinity for pod assignment"
+            "description": "Affinity for pod assignment",
+            "default": {}
         },
         "nodeSelector": {
             "type": "object",
-            "default": {},
-            "description": "Node labels for pod assignment"
+            "description": "Node labels for pod assignment",
+            "default": {}
         },
         "tolerations": {
             "type": "array",
-            "default": [],
-            "description": "Tolerations for pod assignment"
+            "description": "Tolerations for pod assignment",
+            "default": []
         },
         "podLabels": {
             "type": "object",
-            "default": {},
-            "description": "Extra labels for Kubewatch pods"
+            "description": "Extra labels for Kubewatch pods",
+            "default": {}
         },
         "podAnnotations": {
             "type": "object",
-            "default": {},
-            "description": "Annotations for Kubewatch pods"
+            "description": "Annotations for Kubewatch pods",
+            "default": {}
         },
         "extraVolumes": {
             "type": "array",
-            "default": [],
-            "description": "Optionally specify extra list of additional volumes for Kubewatch pods"
+            "description": "Optionally specify extra list of additional volumes for Kubewatch pods",
+            "default": []
         },
         "extraVolumeMounts": {
             "type": "array",
-            "default": [],
-            "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)"
+            "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)",
+            "default": []
         },
         "initContainers": {
             "type": "object",
-            "default": {},
-            "description": "Add additional init containers to the Kubewatch pods"
+            "description": "Add additional init containers to the Kubewatch pods",
+            "default": {}
         },
         "sidecars": {
             "type": "object",
-            "default": {},
-            "description": "Add additional sidecar containers to the Kubewatch pods"
+            "description": "Add additional sidecar containers to the Kubewatch pods",
+            "default": {}
         },
         "rbac": {
             "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Weather to create & use RBAC resources or not"
+                    "description": "Weather to create & use RBAC resources or not",
+                    "default": false
                 }
             }
         },
@@ -569,36 +569,36 @@
             "properties": {
                 "create": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Enable the creation of a ServiceAccount for Kubewatch pods"
+                    "description": "Enable the creation of a ServiceAccount for Kubewatch pods",
+                    "default": true
                 },
                 "name": {
                     "type": "string",
-                    "default": "",
-                    "description": "Name of the created ServiceAccount"
+                    "description": "Name of the created ServiceAccount",
+                    "default": ""
                 }
             }
         },
         "inventedArray": {
             "type": "array",
+            "description": "Test parameter to check arrays",
             "default": [
                 "a",
                 "b"
-            ],
-            "description": "Test parameter to check arrays"
+            ]
         },
         "arrayModifier": {
             "type": "array",
+            "description": "Test parameter for modifier array",
             "default": [
                 "a",
                 "b"
-            ],
-            "description": "Test parameter for modifier array"
+            ]
         },
         "configuration": {
             "type": "string",
-            "default": "global\n  log stdout format raw local0\n  maxconn 1024\ndefaults\n",
-            "description": "haproxy configuration"
+            "description": "haproxy configuration",
+            "default": "global\n  log stdout format raw local0\n  maxconn 1024\ndefaults\n"
         },
         "jobs": {
             "type": "array",
@@ -670,8 +670,8 @@
             "properties": {
                 "content": {
                     "type": "string",
-                    "default": "whatever",
-                    "description": "Content of the object"
+                    "description": "Content of the object",
+                    "default": "whatever"
                 }
             }
         }

--- a/tests/expected-metadata.json
+++ b/tests/expected-metadata.json
@@ -12,7 +12,7 @@
                 },
                 "imagePullSecrets": {
                     "type": "array",
-                    "default": "[]",
+                    "default": [],
                     "description": "Global Docker registry secret names as an array"
                 }
             }
@@ -29,22 +29,22 @@
         },
         "commonLabels": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Labels to add to all deployed objects"
         },
         "commonAnnotations": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Annotations to add to all deployed objects"
         },
         "extraDeploy": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Array of extra objects to deploy with the release"
         },
         "hostAliases": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Add deployment host aliases"
         },
         "image": {
@@ -72,7 +72,7 @@
                 },
                 "pullSecrets": {
                     "type": "array",
-                    "default": "[]",
+                    "default": [],
                     "description": "Specify docker-registry secret names as an array"
                 }
             }
@@ -179,8 +179,18 @@
         },
         "webhook": {
             "type": "object",
-            "default": "{}",
-            "description": "Enable Webhook notifications"
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": ""
+                },
+                "url": {
+                    "type": "string",
+                    "default": "",
+                    "description": ""
+                }
+            }
         },
         "smtp": {
             "type": "object",
@@ -299,12 +309,12 @@
         },
         "command": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Override default container command (useful when using custom images)"
         },
         "args": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Override default container args (useful when using custom images)"
         },
         "extraEnvVars": {
@@ -371,6 +381,21 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Set Kubewatch container's Security Context runAsNonRoot"
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "default": {},
+                    "description": ""
+                },
+                "requests": {
+                    "type": "object",
+                    "default": {},
+                    "description": ""
                 }
             }
         },
@@ -446,12 +471,12 @@
         },
         "customLivenessProbe": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Override default liveness probe"
         },
         "customReadinessProbe": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Override default readiness probe"
         },
         "podAffinityPreset": {
@@ -479,54 +504,54 @@
                 },
                 "values": {
                     "type": "array",
-                    "default": "[]",
+                    "default": [],
                     "description": "Node label values to match. Ignored if `affinity` is set"
                 }
             }
         },
         "affinity": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Affinity for pod assignment"
         },
         "nodeSelector": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Node labels for pod assignment"
         },
         "tolerations": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Tolerations for pod assignment"
         },
         "podLabels": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Extra labels for Kubewatch pods"
         },
         "podAnnotations": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Annotations for Kubewatch pods"
         },
         "extraVolumes": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Optionally specify extra list of additional volumes for Kubewatch pods"
         },
         "extraVolumeMounts": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)"
         },
         "initContainers": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Add additional init containers to the Kubewatch pods"
         },
         "sidecars": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Add additional sidecar containers to the Kubewatch pods"
         },
         "rbac": {
@@ -556,17 +581,23 @@
         },
         "inventedArray": {
             "type": "array",
-            "default": "[\"a\",\"b\"]",
+            "default": [
+                "a",
+                "b"
+            ],
             "description": "Test parameter to check arrays"
         },
         "arrayModifier": {
             "type": "array",
-            "default": "[]",
+            "default": [
+                "a",
+                "b"
+            ],
             "description": "Test parameter for modifier array"
         },
         "configuration": {
             "type": "string",
-            "default": "\"\"",
+            "default": "global\n  log stdout format raw local0\n  maxconn 1024\ndefaults\n",
             "description": "haproxy configuration"
         },
         "jobs": {

--- a/tests/test-metadata.json
+++ b/tests/test-metadata.json
@@ -7,73 +7,73 @@
             "properties": {
                 "imageRegistry": {
                     "type": "string",
-                    "default": "",
-                    "description": "Global Docker image registry"
+                    "description": "Global Docker image registry",
+                    "default": ""
                 },
                 "imagePullSecrets": {
                     "type": "array",
-                    "default": [],
-                    "description": "Global Docker registry secret names as an array"
+                    "description": "Global Docker registry secret names as an array",
+                    "default": []
                 }
             }
         },
         "nameOverride": {
             "type": "string",
-            "default": "",
-            "description": "String to partially override common.names.fullname"
+            "description": "String to partially override common.names.fullname",
+            "default": ""
         },
         "fullnameOverride": {
             "type": "string",
-            "default": "",
-            "description": "String to fully override common.names.fullname"
+            "description": "String to fully override common.names.fullname",
+            "default": ""
         },
         "commonLabels": {
             "type": "object",
-            "default": {},
-            "description": "Labels to add to all deployed objects"
+            "description": "Labels to add to all deployed objects",
+            "default": {}
         },
         "commonAnnotations": {
             "type": "object",
-            "default": {},
-            "description": "Annotations to add to all deployed objects"
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
         },
         "extraDeploy": {
             "type": "array",
-            "default": [],
-            "description": "Array of extra objects to deploy with the release"
+            "description": "Array of extra objects to deploy with the release",
+            "default": []
         },
         "hostAliases": {
             "type": "array",
-            "default": [],
-            "description": "Add deployment host aliases"
+            "description": "Add deployment host aliases",
+            "default": []
         },
         "image": {
             "type": "object",
             "properties": {
                 "registry": {
                     "type": "string",
-                    "default": "docker.io",
-                    "description": "Kubewatch image registry"
+                    "description": "Kubewatch image registry",
+                    "default": "docker.io"
                 },
                 "repository": {
                     "type": "string",
-                    "default": "bitnami/kubewatch",
-                    "description": "Kubewatch image name"
+                    "description": "Kubewatch image name",
+                    "default": "bitnami/kubewatch"
                 },
                 "tag": {
                     "type": "string",
-                    "default": "0.1.0-debian-10-r162",
-                    "description": "Kubewatch image tag"
+                    "description": "Kubewatch image tag",
+                    "default": "0.1.0-debian-10-r162"
                 },
                 "pullPolicy": {
                     "type": "string",
-                    "default": "IfNotPresent",
-                    "description": "Kubewatch image tag"
+                    "description": "Kubewatch image tag",
+                    "default": "IfNotPresent"
                 },
                 "pullSecrets": {
                     "type": "array",
-                    "default": [],
-                    "description": "Specify docker-registry secret names as an array"
+                    "description": "Specify docker-registry secret names as an array",
+                    "default": []
                 }
             }
         },
@@ -82,18 +82,18 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Enable Slack notifications"
+                    "description": "Enable Slack notifications",
+                    "default": true
                 },
                 "channel": {
                     "type": "string",
-                    "default": "XXXX",
-                    "description": "Slack channel to notify"
+                    "description": "Slack channel to notify",
+                    "default": "XXXX"
                 },
                 "token": {
                     "type": "string",
-                    "default": "XXXX",
-                    "description": "Slack API token"
+                    "description": "Slack API token",
+                    "default": "XXXX"
                 }
             }
         },
@@ -102,23 +102,23 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable HipChat notifications"
+                    "description": "Enable HipChat notifications",
+                    "default": false
                 },
                 "room": {
                     "type": "string",
-                    "default": "",
-                    "description": "HipChat room to notify"
+                    "description": "HipChat room to notify",
+                    "default": ""
                 },
                 "token": {
                     "type": "string",
-                    "default": "",
-                    "description": "HipChat token"
+                    "description": "HipChat token",
+                    "default": ""
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": "HipChat URL"
+                    "description": "HipChat URL",
+                    "default": ""
                 }
             }
         },
@@ -127,23 +127,23 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable Mattermost notifications"
+                    "description": "Enable Mattermost notifications",
+                    "default": false
                 },
                 "channel": {
                     "type": "string",
-                    "default": "",
-                    "description": "Mattermost channel to notify"
+                    "description": "Mattermost channel to notify",
+                    "default": ""
                 },
                 "username": {
                     "type": "string",
-                    "default": "",
-                    "description": "Mattermost user to notify"
+                    "description": "Mattermost user to notify",
+                    "default": ""
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": "Mattermost URL"
+                    "description": "Mattermost URL",
+                    "default": ""
                 }
             }
         },
@@ -152,13 +152,13 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable Flock notifications"
+                    "description": "Enable Flock notifications",
+                    "default": false
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": "Flock URL"
+                    "description": "Flock URL",
+                    "default": ""
                 }
             }
         },
@@ -167,13 +167,13 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable Microsoft Teams notifications"
+                    "description": "Enable Microsoft Teams notifications",
+                    "default": false
                 },
                 "webhookurl": {
                     "type": "string",
-                    "default": "",
-                    "description": "Microsoft Teams webhook URL"
+                    "description": "Microsoft Teams webhook URL",
+                    "default": ""
                 }
             }
         },
@@ -182,13 +182,13 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": ""
+                    "description": "",
+                    "default": false
                 },
                 "url": {
                     "type": "string",
-                    "default": "",
-                    "description": ""
+                    "description": "",
+                    "default": ""
                 }
             }
         },
@@ -197,61 +197,61 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable SMTP (email) notifications"
+                    "description": "Enable SMTP (email) notifications",
+                    "default": false
                 },
                 "to": {
                     "type": "string",
-                    "default": "",
-                    "description": "Destination email address (required)"
+                    "description": "Destination email address (required)",
+                    "default": ""
                 },
                 "from": {
                     "type": "string",
-                    "default": "",
-                    "description": "Source email address (required)"
+                    "description": "Source email address (required)",
+                    "default": ""
                 },
                 "hello": {
                     "type": "string",
-                    "default": "",
-                    "description": "SMTP hello field (optional)"
+                    "description": "SMTP hello field (optional)",
+                    "default": ""
                 },
                 "smarthost": {
                     "type": "string",
-                    "default": "",
-                    "description": "SMTP server address (name:port) (required)"
+                    "description": "SMTP server address (name:port) (required)",
+                    "default": ""
                 },
                 "subject": {
                     "type": "string",
-                    "default": "",
-                    "description": "SMTP subject for the email"
+                    "description": "SMTP subject for the email",
+                    "default": ""
                 },
                 "requireTLS": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Force STARTTLS"
+                    "description": "Force STARTTLS",
+                    "default": false
                 },
                 "auth": {
                     "type": "object",
                     "properties": {
                         "username": {
                             "type": "string",
-                            "default": "",
-                            "description": "Username for LOGIN and PLAIN auth mech"
+                            "description": "Username for LOGIN and PLAIN auth mech",
+                            "default": ""
                         },
                         "password": {
                             "type": "string",
-                            "default": "",
-                            "description": "Password for LOGIN and PLAIN auth mech"
+                            "description": "Password for LOGIN and PLAIN auth mech",
+                            "default": ""
                         },
                         "secret": {
                             "type": "string",
-                            "default": "",
-                            "description": "Secret for CRAM-MD5 auth mech"
+                            "description": "Secret for CRAM-MD5 auth mech",
+                            "default": ""
                         },
                         "identity": {
                             "type": "string",
-                            "default": "",
-                            "description": "Identity for PLAIN auth mech"
+                            "description": "Identity for PLAIN auth mech",
+                            "default": ""
                         }
                     }
                 }
@@ -259,63 +259,63 @@
         },
         "namespaceToWatch": {
             "type": "string",
-            "default": "",
-            "description": "Namespace to watch, leave it empty for watching all"
+            "description": "Namespace to watch, leave it empty for watching all",
+            "default": ""
         },
         "resourcesToWatch": {
             "type": "object",
             "properties": {
                 "pod": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Watch changes to Pods"
+                    "description": "Watch changes to Pods",
+                    "default": true
                 },
                 "deployment": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Watch changes to Deployments"
+                    "description": "Watch changes to Deployments",
+                    "default": true
                 },
                 "replicationcontroller": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to ReplicationControllers"
+                    "description": "Watch changes to ReplicationControllers",
+                    "default": false
                 },
                 "replicaset": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to ReplicaSets"
+                    "description": "Watch changes to ReplicaSets",
+                    "default": false
                 },
                 "daemonset": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to DaemonSets"
+                    "description": "Watch changes to DaemonSets",
+                    "default": false
                 },
                 "services": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to Services"
+                    "description": "Watch changes to Services",
+                    "default": false
                 },
                 "job": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to Jobs"
+                    "description": "Watch changes to Jobs",
+                    "default": false
                 },
                 "persistentvolume": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Watch changes to PersistentVolumes"
+                    "description": "Watch changes to PersistentVolumes",
+                    "default": false
                 }
             }
         },
         "command": {
             "type": "array",
-            "default": [],
-            "description": "Override default container command (useful when using custom images)"
+            "description": "Override default container command (useful when using custom images)",
+            "default": []
         },
         "args": {
             "type": "array",
-            "default": [],
-            "description": "Override default container args (useful when using custom images)"
+            "description": "Override default container args (useful when using custom images)",
+            "default": []
         },
         "extraEnvVars": {
             "type": "array",
@@ -336,31 +336,31 @@
         },
         "extraEnvVarsCM": {
             "type": "string",
-            "default": "",
-            "description": "Name of existing ConfigMap containing extra env vars"
+            "description": "Name of existing ConfigMap containing extra env vars",
+            "default": ""
         },
         "extraEnvVarsSecret": {
             "type": "string",
-            "default": "",
-            "description": "Name of existing Secret containing extra env vars"
+            "description": "Name of existing Secret containing extra env vars",
+            "default": ""
         },
         "replicaCount": {
             "type": "number",
-            "default": 1,
-            "description": "Number of Kubewatch replicas to deploy"
+            "description": "Number of Kubewatch replicas to deploy",
+            "default": 1
         },
         "podSecurityContext": {
             "type": "object",
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enabled Kubewatch pods' Security Context"
+                    "description": "Enabled Kubewatch pods' Security Context",
+                    "default": false
                 },
                 "fsGroup": {
                     "type": "number",
-                    "default": 1001,
-                    "description": "Set Kubewatch pod's Security Context fsGroup"
+                    "description": "Set Kubewatch pod's Security Context fsGroup",
+                    "default": 1001
                 }
             }
         },
@@ -369,18 +369,18 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enabled Kubewatch containers' Security Context"
+                    "description": "Enabled Kubewatch containers' Security Context",
+                    "default": false
                 },
                 "runAsUser": {
                     "type": "number",
-                    "default": 1001,
-                    "description": "Set Kubewatch container's Security Context runAsUser"
+                    "description": "Set Kubewatch container's Security Context runAsUser",
+                    "default": 1001
                 },
                 "runAsNonRoot": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Set Kubewatch container's Security Context runAsNonRoot"
+                    "description": "Set Kubewatch container's Security Context runAsNonRoot",
+                    "default": true
                 }
             }
         },
@@ -389,13 +389,13 @@
             "properties": {
                 "limits": {
                     "type": "object",
-                    "default": {},
-                    "description": ""
+                    "description": "",
+                    "default": {}
                 },
                 "requests": {
                     "type": "object",
-                    "default": {},
-                    "description": ""
+                    "description": "",
+                    "default": {}
                 }
             }
         },
@@ -404,33 +404,33 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable livenessProbe"
+                    "description": "Enable livenessProbe",
+                    "default": false
                 },
                 "initialDelaySeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Initial delay seconds for livenessProbe"
+                    "description": "Initial delay seconds for livenessProbe",
+                    "default": 10
                 },
                 "periodSeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Period seconds for livenessProbe"
+                    "description": "Period seconds for livenessProbe",
+                    "default": 10
                 },
                 "timeoutSeconds": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Timeout seconds for livenessProbe"
+                    "description": "Timeout seconds for livenessProbe",
+                    "default": 1
                 },
                 "failureThreshold": {
                     "type": "number",
-                    "default": 3,
-                    "description": "Failure threshold for livenessProbe"
+                    "description": "Failure threshold for livenessProbe",
+                    "default": 3
                 },
                 "successThreshold": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Success threshold for livenessProbe"
+                    "description": "Success threshold for livenessProbe",
+                    "default": 1
                 }
             }
         },
@@ -439,128 +439,128 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Enable readinessProbe"
+                    "description": "Enable readinessProbe",
+                    "default": false
                 },
                 "initialDelaySeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Initial delay seconds for readinessProbe"
+                    "description": "Initial delay seconds for readinessProbe",
+                    "default": 10
                 },
                 "periodSeconds": {
                     "type": "number",
-                    "default": 10,
-                    "description": "Period seconds for readinessProbe"
+                    "description": "Period seconds for readinessProbe",
+                    "default": 10
                 },
                 "timeoutSeconds": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Timeout seconds for readinessProbe"
+                    "description": "Timeout seconds for readinessProbe",
+                    "default": 1
                 },
                 "failureThreshold": {
                     "type": "number",
-                    "default": 3,
-                    "description": "Failure threshold for readinessProbe"
+                    "description": "Failure threshold for readinessProbe",
+                    "default": 3
                 },
                 "successThreshold": {
                     "type": "number",
-                    "default": 1,
-                    "description": "Success threshold for readinessProbe"
+                    "description": "Success threshold for readinessProbe",
+                    "default": 1
                 }
             }
         },
         "customLivenessProbe": {
             "type": "object",
-            "default": {},
-            "description": "Override default liveness probe"
+            "description": "Override default liveness probe",
+            "default": {}
         },
         "customReadinessProbe": {
             "type": "object",
-            "default": {},
-            "description": "Override default readiness probe"
+            "description": "Override default readiness probe",
+            "default": {}
         },
         "podAffinityPreset": {
             "type": "string",
-            "default": "",
-            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`"
+            "description": "Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": ""
         },
         "podAntiAffinityPreset": {
             "type": "string",
-            "default": "soft",
-            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`"
+            "description": "Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+            "default": "soft"
         },
         "nodeAffinityPreset": {
             "type": "object",
             "properties": {
                 "type": {
                     "type": "string",
-                    "default": "",
-                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`"
+                    "description": "Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
                 },
                 "key": {
                     "type": "string",
-                    "default": "",
-                    "description": "Node label key to match. Ignored if `affinity` is set"
+                    "description": "Node label key to match. Ignored if `affinity` is set",
+                    "default": ""
                 },
                 "values": {
                     "type": "array",
-                    "default": [],
-                    "description": "Node label values to match. Ignored if `affinity` is set"
+                    "description": "Node label values to match. Ignored if `affinity` is set",
+                    "default": []
                 }
             }
         },
         "affinity": {
             "type": "object",
-            "default": {},
-            "description": "Affinity for pod assignment"
+            "description": "Affinity for pod assignment",
+            "default": {}
         },
         "nodeSelector": {
             "type": "object",
-            "default": {},
-            "description": "Node labels for pod assignment"
+            "description": "Node labels for pod assignment",
+            "default": {}
         },
         "tolerations": {
             "type": "array",
-            "default": [],
-            "description": "Tolerations for pod assignment"
+            "description": "Tolerations for pod assignment",
+            "default": []
         },
         "podLabels": {
             "type": "object",
-            "default": {},
-            "description": "Extra labels for Kubewatch pods"
+            "description": "Extra labels for Kubewatch pods",
+            "default": {}
         },
         "podAnnotations": {
             "type": "object",
-            "default": {},
-            "description": "Annotations for Kubewatch pods"
+            "description": "Annotations for Kubewatch pods",
+            "default": {}
         },
         "extraVolumes": {
             "type": "array",
-            "default": [],
-            "description": "Optionally specify extra list of additional volumes for Kubewatch pods"
+            "description": "Optionally specify extra list of additional volumes for Kubewatch pods",
+            "default": []
         },
         "extraVolumeMounts": {
             "type": "array",
-            "default": [],
-            "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)"
+            "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)",
+            "default": []
         },
         "initContainers": {
             "type": "object",
-            "default": {},
-            "description": "Add additional init containers to the Kubewatch pods"
+            "description": "Add additional init containers to the Kubewatch pods",
+            "default": {}
         },
         "sidecars": {
             "type": "object",
-            "default": {},
-            "description": "Add additional sidecar containers to the Kubewatch pods"
+            "description": "Add additional sidecar containers to the Kubewatch pods",
+            "default": {}
         },
         "rbac": {
             "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Weather to create & use RBAC resources or not"
+                    "description": "Weather to create & use RBAC resources or not",
+                    "default": false
                 }
             }
         },
@@ -569,36 +569,36 @@
             "properties": {
                 "create": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Enable the creation of a ServiceAccount for Kubewatch pods"
+                    "description": "Enable the creation of a ServiceAccount for Kubewatch pods",
+                    "default": true
                 },
                 "name": {
                     "type": "string",
-                    "default": "",
-                    "description": "Name of the created ServiceAccount"
+                    "description": "Name of the created ServiceAccount",
+                    "default": ""
                 }
             }
         },
         "inventedArray": {
             "type": "array",
+            "description": "Test parameter to check arrays",
             "default": [
                 "a",
                 "b"
-            ],
-            "description": "Test parameter to check arrays"
+            ]
         },
         "arrayModifier": {
             "type": "array",
+            "description": "Test parameter for modifier array",
             "default": [
                 "a",
                 "b"
-            ],
-            "description": "Test parameter for modifier array"
+            ]
         },
         "configuration": {
             "type": "string",
-            "default": "global\n  log stdout format raw local0\n  maxconn 1024\ndefaults\n",
-            "description": "haproxy configuration"
+            "description": "haproxy configuration",
+            "default": "global\n  log stdout format raw local0\n  maxconn 1024\ndefaults\n"
         },
         "jobs": {
             "type": "array",
@@ -670,8 +670,8 @@
             "properties": {
                 "content": {
                     "type": "string",
-                    "default": "whatever",
-                    "description": "Content of the object"
+                    "description": "Content of the object",
+                    "default": "whatever"
                 }
             }
         }

--- a/tests/test-metadata.json
+++ b/tests/test-metadata.json
@@ -12,7 +12,7 @@
                 },
                 "imagePullSecrets": {
                     "type": "array",
-                    "default": "[]",
+                    "default": [],
                     "description": "Global Docker registry secret names as an array"
                 }
             }
@@ -29,22 +29,22 @@
         },
         "commonLabels": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Labels to add to all deployed objects"
         },
         "commonAnnotations": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Annotations to add to all deployed objects"
         },
         "extraDeploy": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Array of extra objects to deploy with the release"
         },
         "hostAliases": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Add deployment host aliases"
         },
         "image": {
@@ -72,7 +72,7 @@
                 },
                 "pullSecrets": {
                     "type": "array",
-                    "default": "[]",
+                    "default": [],
                     "description": "Specify docker-registry secret names as an array"
                 }
             }
@@ -179,8 +179,18 @@
         },
         "webhook": {
             "type": "object",
-            "default": "{}",
-            "description": "Enable Webhook notifications"
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": ""
+                },
+                "url": {
+                    "type": "string",
+                    "default": "",
+                    "description": ""
+                }
+            }
         },
         "smtp": {
             "type": "object",
@@ -299,12 +309,12 @@
         },
         "command": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Override default container command (useful when using custom images)"
         },
         "args": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Override default container args (useful when using custom images)"
         },
         "extraEnvVars": {
@@ -371,6 +381,21 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Set Kubewatch container's Security Context runAsNonRoot"
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "default": {},
+                    "description": ""
+                },
+                "requests": {
+                    "type": "object",
+                    "default": {},
+                    "description": ""
                 }
             }
         },
@@ -446,12 +471,12 @@
         },
         "customLivenessProbe": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Override default liveness probe"
         },
         "customReadinessProbe": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Override default readiness probe"
         },
         "podAffinityPreset": {
@@ -479,54 +504,54 @@
                 },
                 "values": {
                     "type": "array",
-                    "default": "[]",
+                    "default": [],
                     "description": "Node label values to match. Ignored if `affinity` is set"
                 }
             }
         },
         "affinity": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Affinity for pod assignment"
         },
         "nodeSelector": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Node labels for pod assignment"
         },
         "tolerations": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Tolerations for pod assignment"
         },
         "podLabels": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Extra labels for Kubewatch pods"
         },
         "podAnnotations": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Annotations for Kubewatch pods"
         },
         "extraVolumes": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Optionally specify extra list of additional volumes for Kubewatch pods"
         },
         "extraVolumeMounts": {
             "type": "array",
-            "default": "[]",
+            "default": [],
             "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)"
         },
         "initContainers": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Add additional init containers to the Kubewatch pods"
         },
         "sidecars": {
             "type": "object",
-            "default": "{}",
+            "default": {},
             "description": "Add additional sidecar containers to the Kubewatch pods"
         },
         "rbac": {
@@ -556,17 +581,23 @@
         },
         "inventedArray": {
             "type": "array",
-            "default": "[\"a\",\"b\"]",
+            "default": [
+                "a",
+                "b"
+            ],
             "description": "Test parameter to check arrays"
         },
         "arrayModifier": {
             "type": "array",
-            "default": "[]",
+            "default": [
+                "a",
+                "b"
+            ],
             "description": "Test parameter for modifier array"
         },
         "configuration": {
             "type": "string",
-            "default": "\"\"",
+            "default": "global\n  log stdout format raw local0\n  maxconn 1024\ndefaults\n",
             "description": "haproxy configuration"
         },
         "jobs": {


### PR DESCRIPTION
Signed-off-by: Miguel A. Cabrera Minagorri <mcabrera@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

**Description of the change**


This PR is a major refactorization of the logic.
Now the internal data structure is the same for the README and the schema so it does not need to be calculated twice and separately. Instead, what should be rendered is controlled by flags in the Parameter object instance.

This PR also fixes several bugs when generating the schema:

- The `@skip` parameters were not set in the schema, the skip is only to skip render in the README, so now those parameters are set.
- The objects and strings were set as strings in the schema, now they are set as objects and strings.
- The schema for the parameters with modifiers was not being created, not it is.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [x] New features are documented in the README.md
- [x] New features contain a new test at the `tests` folder
- [x] All tests pass running `npm test`

