### PR TITLE
Parser should lazy match modifier close bracket

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -25,10 +25,10 @@ function parseMetadataComments(valuesFilePath, config) {
   const lines = data.split(/\r?\n/);
 
   const parsedValues = [];
-  const paramRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.param}\\s*([^\\s]+)\\s*(\\[.*\\])?\\s*(.*)$`);
+  const paramRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.param}\\s*([^\\s]+)\\s*(\\[.*?\\])?\\s*(.*)$`);
   const sectionRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.section}\\s*(.*)$`);
   const skipRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.skip}\\s*(.*)$`);
-  const extraRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.extra}\\s*([^\\s]+)\\s*(\\[.*\\])?\\s*(.*)$`);
+  const extraRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.extra}\\s*([^\\s]+)\\s*(\\[.*?\\])?\\s*(.*)$`);
 
   let currentSection = ''; // We assume there will always be a section before any parameter. At least one section is required
   lines.forEach((line) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Autogenerate READMEs' tables for Bitnami Helm Charts",
   "main": "index.js",
   "scripts": {

--- a/tests/expected-readme.md
+++ b/tests/expected-readme.md
@@ -109,64 +109,65 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Deployment parameters
 
-| Name                                                  | Description                                                                                        | Value       |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------- |
-| `command`                                             | Override default container command (useful when using custom images)                               | `[]`        |
-| `args`                                                | Override default container args (useful when using custom images)                                  | `[]`        |
-| `extraEnvVars[0].name`                                | Name of the env var                                                                                | `FOO`       |
-| `extraEnvVars[0].value`                               | Value for the env var                                                                              | `bar`       |
-| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                               | `""`        |
-| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                  | `""`        |
-| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                             | `1`         |
-| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                           | `false`     |
-| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                       | `1001`      |
-| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                     | `false`     |
-| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                               | `1001`      |
-| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                            | `true`      |
-| `livenessProbe.enabled`                               | Enable livenessProbe                                                                               | `false`     |
-| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                            | `10`        |
-| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                   | `10`        |
-| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                  | `1`         |
-| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                | `3`         |
-| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                | `1`         |
-| `readinessProbe.enabled`                              | Enable readinessProbe                                                                              | `false`     |
-| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                           | `10`        |
-| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                  | `10`        |
-| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                 | `1`         |
-| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                               | `3`         |
-| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                               | `1`         |
-| `customLivenessProbe`                                 | Override default liveness probe                                                                    | `{}`        |
-| `customReadinessProbe`                                | Override default readiness probe                                                                   | `{}`        |
-| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `""`        |
-| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`           | `soft`      |
-| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `""`        |
-| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                              | `""`        |
-| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                           | `[]`        |
-| `affinity`                                            | Affinity for pod assignment                                                                        | `{}`        |
-| `nodeSelector`                                        | Node labels for pod assignment                                                                     | `{}`        |
-| `tolerations`                                         | Tolerations for pod assignment                                                                     | `[]`        |
-| `podLabels`                                           | Extra labels for Kubewatch pods                                                                    | `{}`        |
-| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                     | `{}`        |
-| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                             | `[]`        |
-| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                | `[]`        |
-| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                               | `{}`        |
-| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                            | `{}`        |
-| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                      | `false`     |
-| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                         | `true`      |
-| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                 | `""`        |
-| `inventedArray`                                       | Test parameter to check arrays                                                                     | `["a","b"]` |
-| `arrayModifier`                                       | Test parameter for modifier array                                                                  | `[]`        |
-| `configuration`                                       | haproxy configuration                                                                              | `""`        |
-| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                   | `""`        |
-| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                       | `""`        |
-| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                          | `{}`        |
-| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                           | `a`         |
-| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                 | `["b"]`     |
-| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                | `d`         |
-| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                       | `{}`        |
-| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree               |             |
-| `extraTest.content`                                   | Content of the object                                                                              | `whatever`  |
-| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README | `[]`        |
+| Name                                                  | Description                                                                                                     | Value       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------- |
+| `command`                                             | Override default container command (useful when using custom images)                                            | `[]`        |
+| `args`                                                | Override default container args (useful when using custom images)                                               | `[]`        |
+| `extraEnvVars[0].name`                                | Name of the env var                                                                                             | `FOO`       |
+| `extraEnvVars[0].value`                               | Value for the env var                                                                                           | `bar`       |
+| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                                            | `""`        |
+| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                               | `""`        |
+| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                                          | `1`         |
+| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                                        | `false`     |
+| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                                    | `1001`      |
+| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                                  | `false`     |
+| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                                            | `1001`      |
+| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                                         | `true`      |
+| `livenessProbe.enabled`                               | Enable livenessProbe                                                                                            | `false`     |
+| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                                         | `10`        |
+| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                                | `10`        |
+| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                               | `1`         |
+| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                             | `3`         |
+| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                             | `1`         |
+| `readinessProbe.enabled`                              | Enable readinessProbe                                                                                           | `false`     |
+| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                                        | `10`        |
+| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                               | `10`        |
+| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                              | `1`         |
+| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                                            | `3`         |
+| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                                            | `1`         |
+| `customLivenessProbe`                                 | Override default liveness probe                                                                                 | `{}`        |
+| `customReadinessProbe`                                | Override default readiness probe                                                                                | `{}`        |
+| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`        |
+| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `soft`      |
+| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`        |
+| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                                           | `""`        |
+| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                                        | `[]`        |
+| `affinity`                                            | Affinity for pod assignment                                                                                     | `{}`        |
+| `nodeSelector`                                        | Node labels for pod assignment                                                                                  | `{}`        |
+| `tolerations`                                         | Tolerations for pod assignment                                                                                  | `[]`        |
+| `podLabels`                                           | Extra labels for Kubewatch pods                                                                                 | `{}`        |
+| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                                  | `{}`        |
+| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                                          | `[]`        |
+| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                             | `[]`        |
+| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                                            | `{}`        |
+| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                                         | `{}`        |
+| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                                   | `false`     |
+| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                                      | `true`      |
+| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                              | `""`        |
+| `inventedArray`                                       | Test parameter to check arrays                                                                                  | `["a","b"]` |
+| `arrayModifier`                                       | Test parameter for modifier array                                                                               | `[]`        |
+| `configuration`                                       | haproxy configuration                                                                                           | `""`        |
+| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                | `""`        |
+| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                    | `""`        |
+| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                                       | `{}`        |
+| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                                        | `a`         |
+| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                              | `["b"]`     |
+| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                             | `d`         |
+| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                                    | `{}`        |
+| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree                            |             |
+| `extraTest.content`                                   | Content of the object                                                                                           | `whatever`  |
+| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README              | `[]`        |
+| `modifierWithSquareBrackets`                          | Additional square brackets should appeare in description. [More information here](#additional-square-brackets). | `{}`        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -290,3 +291,9 @@ Helm performs a lookup for the object based on its group (apps), version (v1), a
 In https://github.com/helm/charts/pull/17285 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
 
 This major version signifies this change.
+
+## Test supporting data
+
+### Additional square brackets
+
+Additional square brackets section of the readme. Which can be linked to from injected Parameters section.

--- a/tests/expected-readme.md
+++ b/tests/expected-readme.md
@@ -109,65 +109,65 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Deployment parameters
 
-| Name                                                  | Description                                                                                                     | Value       |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------- |
-| `command`                                             | Override default container command (useful when using custom images)                                            | `[]`        |
-| `args`                                                | Override default container args (useful when using custom images)                                               | `[]`        |
-| `extraEnvVars[0].name`                                | Name of the env var                                                                                             | `FOO`       |
-| `extraEnvVars[0].value`                               | Value for the env var                                                                                           | `bar`       |
-| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                                            | `""`        |
-| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                               | `""`        |
-| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                                          | `1`         |
-| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                                        | `false`     |
-| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                                    | `1001`      |
-| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                                  | `false`     |
-| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                                            | `1001`      |
-| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                                         | `true`      |
-| `livenessProbe.enabled`                               | Enable livenessProbe                                                                                            | `false`     |
-| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                                         | `10`        |
-| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                                | `10`        |
-| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                               | `1`         |
-| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                             | `3`         |
-| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                             | `1`         |
-| `readinessProbe.enabled`                              | Enable readinessProbe                                                                                           | `false`     |
-| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                                        | `10`        |
-| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                               | `10`        |
-| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                              | `1`         |
-| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                                            | `3`         |
-| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                                            | `1`         |
-| `customLivenessProbe`                                 | Override default liveness probe                                                                                 | `{}`        |
-| `customReadinessProbe`                                | Override default readiness probe                                                                                | `{}`        |
-| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`        |
-| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `soft`      |
-| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`        |
-| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                                           | `""`        |
-| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                                        | `[]`        |
-| `affinity`                                            | Affinity for pod assignment                                                                                     | `{}`        |
-| `nodeSelector`                                        | Node labels for pod assignment                                                                                  | `{}`        |
-| `tolerations`                                         | Tolerations for pod assignment                                                                                  | `[]`        |
-| `podLabels`                                           | Extra labels for Kubewatch pods                                                                                 | `{}`        |
-| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                                  | `{}`        |
-| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                                          | `[]`        |
-| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                             | `[]`        |
-| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                                            | `{}`        |
-| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                                         | `{}`        |
-| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                                   | `false`     |
-| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                                      | `true`      |
-| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                              | `""`        |
-| `inventedArray`                                       | Test parameter to check arrays                                                                                  | `["a","b"]` |
-| `arrayModifier`                                       | Test parameter for modifier array                                                                               | `[]`        |
-| `configuration`                                       | haproxy configuration                                                                                           | `""`        |
-| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                | `""`        |
-| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                    | `""`        |
-| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                                       | `{}`        |
-| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                                        | `a`         |
-| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                              | `["b"]`     |
-| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                             | `d`         |
-| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                                    | `{}`        |
-| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree                            |             |
-| `extraTest.content`                                   | Content of the object                                                                                           | `whatever`  |
-| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README              | `[]`        |
-| `modifierWithSquareBrackets`                          | Additional square brackets should appeare in description. [More information here](#additional-square-brackets). | `{}`        |
+| Name                                                  | Description                                                                                        | Value       |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------- |
+| `command`                                             | Override default container command (useful when using custom images)                               | `[]`        |
+| `args`                                                | Override default container args (useful when using custom images)                                  | `[]`        |
+| `extraEnvVars[0].name`                                | Name of the env var                                                                                | `FOO`       |
+| `extraEnvVars[0].value`                               | Value for the env var                                                                              | `bar`       |
+| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                               | `""`        |
+| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                  | `""`        |
+| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                             | `1`         |
+| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                           | `false`     |
+| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                       | `1001`      |
+| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                     | `false`     |
+| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                               | `1001`      |
+| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                            | `true`      |
+| `livenessProbe.enabled`                               | Enable livenessProbe                                                                               | `false`     |
+| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                            | `10`        |
+| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                   | `10`        |
+| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                  | `1`         |
+| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                | `3`         |
+| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                | `1`         |
+| `readinessProbe.enabled`                              | Enable readinessProbe                                                                              | `false`     |
+| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                           | `10`        |
+| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                  | `10`        |
+| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                 | `1`         |
+| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                               | `3`         |
+| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                               | `1`         |
+| `customLivenessProbe`                                 | Override default liveness probe                                                                    | `{}`        |
+| `customReadinessProbe`                                | Override default readiness probe                                                                   | `{}`        |
+| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `""`        |
+| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`           | `soft`      |
+| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `""`        |
+| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                              | `""`        |
+| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                           | `[]`        |
+| `affinity`                                            | Affinity for pod assignment                                                                        | `{}`        |
+| `nodeSelector`                                        | Node labels for pod assignment                                                                     | `{}`        |
+| `tolerations`                                         | Tolerations for pod assignment                                                                     | `[]`        |
+| `podLabels`                                           | Extra labels for Kubewatch pods                                                                    | `{}`        |
+| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                     | `{}`        |
+| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                             | `[]`        |
+| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                | `[]`        |
+| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                               | `{}`        |
+| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                            | `{}`        |
+| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                      | `false`     |
+| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                         | `true`      |
+| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                 | `""`        |
+| `inventedArray`                                       | Test parameter to check arrays                                                                     | `["a","b"]` |
+| `arrayModifier`                                       | Test parameter for modifier array                                                                  | `[]`        |
+| `configuration`                                       | haproxy configuration                                                                              | `""`        |
+| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                   | `""`        |
+| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                       | `""`        |
+| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                          | `{}`        |
+| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                           | `a`         |
+| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                 | `["b"]`     |
+| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                | `d`         |
+| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                       | `{}`        |
+| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree               |             |
+| `extraTest.content`                                   | Content of the object                                                                              | `whatever`  |
+| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README | `[]`        |
+| `linkInDescription`                                   | Link with square brackets present in description. [More information here](#link-in-description).   | `{}`        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -291,9 +291,3 @@ Helm performs a lookup for the object based on its group (apps), version (v1), a
 In https://github.com/helm/charts/pull/17285 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
 
 This major version signifies this change.
-
-## Test supporting data
-
-### Additional square brackets
-
-Additional square brackets section of the readme. Which can be linked to from injected Parameters section.

--- a/tests/expected-schema.json
+++ b/tests/expected-schema.json
@@ -682,6 +682,21 @@
                 }
             }
         },
+        "modifierWithSquareBrackets": {
+            "type": "object",
+            "properties": {
+                "propertyOne": {
+                    "type": "string",
+                    "description": "",
+                    "default": "valueOne"
+                },
+                "propertyTwo": {
+                    "type": "string",
+                    "description": "",
+                    "default": "valueTwo"
+                }
+            }
+        },
         "extraTest": {
             "type": "object",
             "properties": {

--- a/tests/expected-schema.json
+++ b/tests/expected-schema.json
@@ -682,7 +682,7 @@
                 }
             }
         },
-        "modifierWithSquareBrackets": {
+        "linkInDescription": {
             "type": "object",
             "properties": {
                 "propertyOne": {

--- a/tests/test-readme.md
+++ b/tests/test-readme.md
@@ -109,64 +109,65 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Deployment parameters
 
-| Name                                                  | Description                                                                                        | Value       |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------- |
-| `command`                                             | Override default container command (useful when using custom images)                               | `[]`        |
-| `args`                                                | Override default container args (useful when using custom images)                                  | `[]`        |
-| `extraEnvVars[0].name`                                | Name of the env var                                                                                | `FOO`       |
-| `extraEnvVars[0].value`                               | Value for the env var                                                                              | `bar`       |
-| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                               | `""`        |
-| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                  | `""`        |
-| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                             | `1`         |
-| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                           | `false`     |
-| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                       | `1001`      |
-| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                     | `false`     |
-| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                               | `1001`      |
-| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                            | `true`      |
-| `livenessProbe.enabled`                               | Enable livenessProbe                                                                               | `false`     |
-| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                            | `10`        |
-| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                   | `10`        |
-| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                  | `1`         |
-| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                | `3`         |
-| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                | `1`         |
-| `readinessProbe.enabled`                              | Enable readinessProbe                                                                              | `false`     |
-| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                           | `10`        |
-| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                  | `10`        |
-| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                 | `1`         |
-| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                               | `3`         |
-| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                               | `1`         |
-| `customLivenessProbe`                                 | Override default liveness probe                                                                    | `{}`        |
-| `customReadinessProbe`                                | Override default readiness probe                                                                   | `{}`        |
-| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `""`        |
-| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`           | `soft`      |
-| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `""`        |
-| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                              | `""`        |
-| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                           | `[]`        |
-| `affinity`                                            | Affinity for pod assignment                                                                        | `{}`        |
-| `nodeSelector`                                        | Node labels for pod assignment                                                                     | `{}`        |
-| `tolerations`                                         | Tolerations for pod assignment                                                                     | `[]`        |
-| `podLabels`                                           | Extra labels for Kubewatch pods                                                                    | `{}`        |
-| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                     | `{}`        |
-| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                             | `[]`        |
-| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                | `[]`        |
-| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                               | `{}`        |
-| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                            | `{}`        |
-| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                      | `false`     |
-| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                         | `true`      |
-| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                 | `""`        |
-| `inventedArray`                                       | Test parameter to check arrays                                                                     | `["a","b"]` |
-| `arrayModifier`                                       | Test parameter for modifier array                                                                  | `[]`        |
-| `configuration`                                       | haproxy configuration                                                                              | `""`        |
-| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                   | `""`        |
-| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                       | `""`        |
-| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                          | `{}`        |
-| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                           | `a`         |
-| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                 | `["b"]`     |
-| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                | `d`         |
-| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                       | `{}`        |
-| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree               |             |
-| `extraTest.content`                                   | Content of the object                                                                              | `whatever`  |
-| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README | `[]`        |
+| Name                                                  | Description                                                                                                     | Value       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------- |
+| `command`                                             | Override default container command (useful when using custom images)                                            | `[]`        |
+| `args`                                                | Override default container args (useful when using custom images)                                               | `[]`        |
+| `extraEnvVars[0].name`                                | Name of the env var                                                                                             | `FOO`       |
+| `extraEnvVars[0].value`                               | Value for the env var                                                                                           | `bar`       |
+| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                                            | `""`        |
+| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                               | `""`        |
+| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                                          | `1`         |
+| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                                        | `false`     |
+| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                                    | `1001`      |
+| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                                  | `false`     |
+| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                                            | `1001`      |
+| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                                         | `true`      |
+| `livenessProbe.enabled`                               | Enable livenessProbe                                                                                            | `false`     |
+| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                                         | `10`        |
+| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                                | `10`        |
+| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                               | `1`         |
+| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                             | `3`         |
+| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                             | `1`         |
+| `readinessProbe.enabled`                              | Enable readinessProbe                                                                                           | `false`     |
+| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                                        | `10`        |
+| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                               | `10`        |
+| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                              | `1`         |
+| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                                            | `3`         |
+| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                                            | `1`         |
+| `customLivenessProbe`                                 | Override default liveness probe                                                                                 | `{}`        |
+| `customReadinessProbe`                                | Override default readiness probe                                                                                | `{}`        |
+| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`        |
+| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `soft`      |
+| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`        |
+| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                                           | `""`        |
+| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                                        | `[]`        |
+| `affinity`                                            | Affinity for pod assignment                                                                                     | `{}`        |
+| `nodeSelector`                                        | Node labels for pod assignment                                                                                  | `{}`        |
+| `tolerations`                                         | Tolerations for pod assignment                                                                                  | `[]`        |
+| `podLabels`                                           | Extra labels for Kubewatch pods                                                                                 | `{}`        |
+| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                                  | `{}`        |
+| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                                          | `[]`        |
+| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                             | `[]`        |
+| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                                            | `{}`        |
+| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                                         | `{}`        |
+| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                                   | `false`     |
+| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                                      | `true`      |
+| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                              | `""`        |
+| `inventedArray`                                       | Test parameter to check arrays                                                                                  | `["a","b"]` |
+| `arrayModifier`                                       | Test parameter for modifier array                                                                               | `[]`        |
+| `configuration`                                       | haproxy configuration                                                                                           | `""`        |
+| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                | `""`        |
+| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                    | `""`        |
+| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                                       | `{}`        |
+| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                                        | `a`         |
+| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                              | `["b"]`     |
+| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                             | `d`         |
+| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                                    | `{}`        |
+| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree                            |             |
+| `extraTest.content`                                   | Content of the object                                                                                           | `whatever`  |
+| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README              | `[]`        |
+| `modifierWithSquareBrackets`                          | Additional square brackets should appeare in description. [More information here](#additional-square-brackets). | `{}`        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -290,3 +291,9 @@ Helm performs a lookup for the object based on its group (apps), version (v1), a
 In https://github.com/helm/charts/pull/17285 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
 
 This major version signifies this change.
+
+## Test supporting data
+
+### Additional square brackets
+
+Additional square brackets section of the readme. Which can be linked to from injected Parameters section.

--- a/tests/test-readme.md
+++ b/tests/test-readme.md
@@ -109,65 +109,65 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Deployment parameters
 
-| Name                                                  | Description                                                                                                     | Value       |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------- |
-| `command`                                             | Override default container command (useful when using custom images)                                            | `[]`        |
-| `args`                                                | Override default container args (useful when using custom images)                                               | `[]`        |
-| `extraEnvVars[0].name`                                | Name of the env var                                                                                             | `FOO`       |
-| `extraEnvVars[0].value`                               | Value for the env var                                                                                           | `bar`       |
-| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                                            | `""`        |
-| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                               | `""`        |
-| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                                          | `1`         |
-| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                                        | `false`     |
-| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                                    | `1001`      |
-| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                                  | `false`     |
-| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                                            | `1001`      |
-| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                                         | `true`      |
-| `livenessProbe.enabled`                               | Enable livenessProbe                                                                                            | `false`     |
-| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                                         | `10`        |
-| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                                | `10`        |
-| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                               | `1`         |
-| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                             | `3`         |
-| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                             | `1`         |
-| `readinessProbe.enabled`                              | Enable readinessProbe                                                                                           | `false`     |
-| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                                        | `10`        |
-| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                               | `10`        |
-| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                              | `1`         |
-| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                                            | `3`         |
-| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                                            | `1`         |
-| `customLivenessProbe`                                 | Override default liveness probe                                                                                 | `{}`        |
-| `customReadinessProbe`                                | Override default readiness probe                                                                                | `{}`        |
-| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`        |
-| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `soft`      |
-| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`        |
-| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                                           | `""`        |
-| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                                        | `[]`        |
-| `affinity`                                            | Affinity for pod assignment                                                                                     | `{}`        |
-| `nodeSelector`                                        | Node labels for pod assignment                                                                                  | `{}`        |
-| `tolerations`                                         | Tolerations for pod assignment                                                                                  | `[]`        |
-| `podLabels`                                           | Extra labels for Kubewatch pods                                                                                 | `{}`        |
-| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                                  | `{}`        |
-| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                                          | `[]`        |
-| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                             | `[]`        |
-| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                                            | `{}`        |
-| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                                         | `{}`        |
-| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                                   | `false`     |
-| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                                      | `true`      |
-| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                              | `""`        |
-| `inventedArray`                                       | Test parameter to check arrays                                                                                  | `["a","b"]` |
-| `arrayModifier`                                       | Test parameter for modifier array                                                                               | `[]`        |
-| `configuration`                                       | haproxy configuration                                                                                           | `""`        |
-| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                | `""`        |
-| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                    | `""`        |
-| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                                       | `{}`        |
-| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                                        | `a`         |
-| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                              | `["b"]`     |
-| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                             | `d`         |
-| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                                    | `{}`        |
-| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree                            |             |
-| `extraTest.content`                                   | Content of the object                                                                                           | `whatever`  |
-| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README              | `[]`        |
-| `modifierWithSquareBrackets`                          | Additional square brackets should appeare in description. [More information here](#additional-square-brackets). | `{}`        |
+| Name                                                  | Description                                                                                        | Value       |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------- |
+| `command`                                             | Override default container command (useful when using custom images)                               | `[]`        |
+| `args`                                                | Override default container args (useful when using custom images)                                  | `[]`        |
+| `extraEnvVars[0].name`                                | Name of the env var                                                                                | `FOO`       |
+| `extraEnvVars[0].value`                               | Value for the env var                                                                              | `bar`       |
+| `extraEnvVarsCM`                                      | Name of existing ConfigMap containing extra env vars                                               | `""`        |
+| `extraEnvVarsSecret`                                  | Name of existing Secret containing extra env vars                                                  | `""`        |
+| `replicaCount`                                        | Number of Kubewatch replicas to deploy                                                             | `1`         |
+| `podSecurityContext.enabled`                          | Enabled Kubewatch pods' Security Context                                                           | `false`     |
+| `podSecurityContext.fsGroup`                          | Set Kubewatch pod's Security Context fsGroup                                                       | `1001`      |
+| `containerSecurityContext.enabled`                    | Enabled Kubewatch containers' Security Context                                                     | `false`     |
+| `containerSecurityContext.runAsUser`                  | Set Kubewatch container's Security Context runAsUser                                               | `1001`      |
+| `containerSecurityContext.runAsNonRoot`               | Set Kubewatch container's Security Context runAsNonRoot                                            | `true`      |
+| `livenessProbe.enabled`                               | Enable livenessProbe                                                                               | `false`     |
+| `livenessProbe.initialDelaySeconds`                   | Initial delay seconds for livenessProbe                                                            | `10`        |
+| `livenessProbe.periodSeconds`                         | Period seconds for livenessProbe                                                                   | `10`        |
+| `livenessProbe.timeoutSeconds`                        | Timeout seconds for livenessProbe                                                                  | `1`         |
+| `livenessProbe.failureThreshold`                      | Failure threshold for livenessProbe                                                                | `3`         |
+| `livenessProbe.successThreshold`                      | Success threshold for livenessProbe                                                                | `1`         |
+| `readinessProbe.enabled`                              | Enable readinessProbe                                                                              | `false`     |
+| `readinessProbe.initialDelaySeconds`                  | Initial delay seconds for readinessProbe                                                           | `10`        |
+| `readinessProbe.periodSeconds`                        | Period seconds for readinessProbe                                                                  | `10`        |
+| `readinessProbe.timeoutSeconds`                       | Timeout seconds for readinessProbe                                                                 | `1`         |
+| `readinessProbe.failureThreshold`                     | Failure threshold for readinessProbe                                                               | `3`         |
+| `readinessProbe.successThreshold`                     | Success threshold for readinessProbe                                                               | `1`         |
+| `customLivenessProbe`                                 | Override default liveness probe                                                                    | `{}`        |
+| `customReadinessProbe`                                | Override default readiness probe                                                                   | `{}`        |
+| `podAffinityPreset`                                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `""`        |
+| `podAntiAffinityPreset`                               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`           | `soft`      |
+| `nodeAffinityPreset.type`                             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `""`        |
+| `nodeAffinityPreset.key`                              | Node label key to match. Ignored if `affinity` is set                                              | `""`        |
+| `nodeAffinityPreset.values`                           | Node label values to match. Ignored if `affinity` is set                                           | `[]`        |
+| `affinity`                                            | Affinity for pod assignment                                                                        | `{}`        |
+| `nodeSelector`                                        | Node labels for pod assignment                                                                     | `{}`        |
+| `tolerations`                                         | Tolerations for pod assignment                                                                     | `[]`        |
+| `podLabels`                                           | Extra labels for Kubewatch pods                                                                    | `{}`        |
+| `podAnnotations`                                      | Annotations for Kubewatch pods                                                                     | `{}`        |
+| `extraVolumes`                                        | Optionally specify extra list of additional volumes for Kubewatch pods                             | `[]`        |
+| `extraVolumeMounts`                                   | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)                | `[]`        |
+| `initContainers`                                      | Add additional init containers to the Kubewatch pods                                               | `{}`        |
+| `sidecars`                                            | Add additional sidecar containers to the Kubewatch pods                                            | `{}`        |
+| `rbac.create`                                         | Weather to create & use RBAC resources or not                                                      | `false`     |
+| `serviceAccount.create`                               | Enable the creation of a ServiceAccount for Kubewatch pods                                         | `true`      |
+| `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                 | `""`        |
+| `inventedArray`                                       | Test parameter to check arrays                                                                     | `["a","b"]` |
+| `arrayModifier`                                       | Test parameter for modifier array                                                                  | `[]`        |
+| `configuration`                                       | haproxy configuration                                                                              | `""`        |
+| `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                   | `""`        |
+| `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                       | `""`        |
+| `jobs[0].resources.limits`                            | The resources limits override for the Job                                                          | `{}`        |
+| `jobs[0].newOption.subArray[0].object`                | Test object inside Arrat                                                                           | `a`         |
+| `jobs[0].newOption.subArray[0].plainArray`            | Test nested arrays                                                                                 | `["b"]`     |
+| `jobs[0].newOption.subArray[0].threeLevelsArray[0].c` | Test 3 levels array                                                                                | `d`         |
+| `jobs[0].newOption.subArray[0].emptyObject`           | Empty object                                                                                       | `{}`        |
+| `extraTest`                                           | An object that we want to document even though it is not at the end of the YAML tree               |             |
+| `extraTest.content`                                   | Content of the object                                                                              | `whatever`  |
+| `forceSchemaArrayModifier`                            | The parameter should appear completely into the schema but with the modifier value into the README | `[]`        |
+| `linkInDescription`                                   | Link with square brackets present in description. [More information here](#link-in-description).   | `{}`        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -291,9 +291,3 @@ Helm performs a lookup for the object based on its group (apps), version (v1), a
 In https://github.com/helm/charts/pull/17285 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
 
 This major version signifies this change.
-
-## Test supporting data
-
-### Additional square brackets
-
-Additional square brackets section of the readme. Which can be linked to from injected Parameters section.

--- a/tests/test-schema.json
+++ b/tests/test-schema.json
@@ -682,6 +682,21 @@
                 }
             }
         },
+        "modifierWithSquareBrackets": {
+            "type": "object",
+            "properties": {
+                "propertyOne": {
+                    "type": "string",
+                    "description": "",
+                    "default": "valueOne"
+                },
+                "propertyTwo": {
+                    "type": "string",
+                    "description": "",
+                    "default": "valueTwo"
+                }
+            }
+        },
         "extraTest": {
             "type": "object",
             "properties": {

--- a/tests/test-schema.json
+++ b/tests/test-schema.json
@@ -682,7 +682,7 @@
                 }
             }
         },
-        "modifierWithSquareBrackets": {
+        "linkInDescription": {
             "type": "object",
             "properties": {
                 "propertyOne": {

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -497,3 +497,9 @@ forceSchemaArrayModifier:
   - w: "x"
     y:
       - "z"
+
+## Invented parameter to test proper modifier consumption
+## @param modifierWithSquareBrackets [object] Additional square brackets should appeare in description. [More information here](#additional-square-brackets).
+modifierWithSquareBrackets:
+  propertyOne: valueOne
+  propertyTwo: valueTwo

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -498,8 +498,8 @@ forceSchemaArrayModifier:
     y:
       - "z"
 
-## Invented parameter to test proper modifier consumption
-## @param modifierWithSquareBrackets [object] Additional square brackets should appeare in description. [More information here](#additional-square-brackets).
-modifierWithSquareBrackets:
+## Invented parameter to test links in descriptions
+## @param linkInDescription [object] Link with square brackets present in description. [More information here](#link-in-description).
+linkInDescription:
   propertyOne: valueOne
   propertyTwo: valueTwo


### PR DESCRIPTION
**Description of the change**

 Add lazy quantifier to modifier parser to allow further square brackets in description. Parser currently consumed entire text up to including final square bracket as a modifier.

 Add tests to support fix.

**Benefits**

Allow additional square brackets in the description when one of the allowed modifiers was already used. This allows using anchor links to other sections of generated README or listing example allowed values.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist**
- [x] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [ ] New features are documented in the README.md
- [x] New features contain a new test at the `tests` folder
- [x] All tests pass running `npm test`

