### PR TITLE
Use null instead of 'null' in null objects schema

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -128,6 +128,9 @@ function generateSchema(value, tree, properties, ignoreDefault = false) {
         description: value.description,
       };
       if (!ignoreDefault) {
+        if (value.value == 'null') {
+          value.value = null;
+        }
         properties[tree[i]].default = value.value;
       }
       if (value.nullable) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Autogenerate READMEs' tables for Bitnami Helm Charts",
   "main": "index.js",
   "scripts": {

--- a/tests/expected-schema.json
+++ b/tests/expected-schema.json
@@ -710,19 +710,19 @@
         "nullable": {
             "type": "object",
             "description": "Nullable parameter",
-            "default": "null",
+            "default": null,
             "nullable": true
         },
         "nullableNullStringWithValueChange": {
             "type": "string",
             "description": "Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`.",
-            "default": "null",
+            "default": null,
             "nullable": true
         },
         "nullableNullString": {
             "type": "string",
             "description": "Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.",
-            "default": "null",
+            "default": null,
             "nullable": true
         },
         "nullableNotNull": {

--- a/tests/test-schema.json
+++ b/tests/test-schema.json
@@ -710,19 +710,19 @@
         "nullable": {
             "type": "object",
             "description": "Nullable parameter",
-            "default": "null",
+            "default": null,
             "nullable": true
         },
         "nullableNullStringWithValueChange": {
             "type": "string",
             "description": "Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`.",
-            "default": "null",
+            "default": null,
             "nullable": true
         },
         "nullableNullString": {
             "type": "string",
             "description": "Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.",
-            "default": "null",
+            "default": null,
             "nullable": true
         },
         "nullableNotNull": {


### PR DESCRIPTION
Signed-off-by: Miguel A. Cabrera Minagorri <mcabrera@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

**Description of the change**

Null objects were being set as `"null"` (note string) instead of `null` into the schema. This PR fixes that and sets it properly.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #39

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [x] New features are documented in the README.md
- [x] New features contain a new test at the `tests` folder
- [x] All tests pass running `npm test`

