### PR TITLE
Support keys with dots and annotations in README

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -69,6 +69,8 @@ function combineMetadataAndValues(valuesObject, valuesMetadata) {
         // Set the value from actual object
         param.value = valuesObject[paramIndex].value;
         param.type = valuesObject[paramIndex].type;
+        // TODO(miguelaeh): Hack to avoid render parameters with dots in keys into the schema. Must be removed once fixed
+        param.schema = valuesObject[paramIndex].schema;
       }
     }
   }

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -79,7 +79,6 @@ function checkKeys(valuesObject, valuesMetadata) {
   const errors = []; // Stores all the errors
   const missingKeys = realKeys.filter((key) => !parsedKeys.includes(key));
   const notFoundKeys = parsedKeys.filter((key) => !realKeys.includes(key));
-
   console.log('INFO: Checking missing metadata...');
   missingKeys.forEach((key) => {
     errors.push(`ERROR: Missing metadata for key: ${key}`);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -85,6 +85,14 @@ function createValuesObject(valuesFilePath) {
   for (let valuePath in dottedFormatProperties) {
     if (Object.prototype.hasOwnProperty.call(dottedFormatProperties, valuePath)) {
       let value = _.get(valuesJSON, valuePath);
+      // TODO(miguelaeh): Variable to avoid render in the schema parameters with dots in the keys.
+      //                  the ocurrences of this variable inside this function must be deleted after fixing it.
+      let renderInSchema = true;
+      if (value === undefined) {
+        // If the value is not found, give a try to our function for complex keys like 'annotations.prometheus.io/scrape'
+        value = _.get(valuesJSON, utils.getArrayPath(valuesJSON, valuePath));
+        renderInSchema = false;
+      }
       let type = typeof value;
 
       // Check if the value is a plain array, an array that only contains strings,
@@ -123,6 +131,7 @@ function createValuesObject(valuesFilePath) {
         param.value = value;
         param.type = type;
         resultValues.push(param);
+        param.schema = renderInSchema;
       }
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,8 +39,31 @@ function containsModifier(parameter, modifier) {
   });
 }
 
+/*
+ *  Returns the value when the keys contain complex strings that cannot be indexed with a dot notation
+ */
+function getArrayPath(obj, path) {
+  let fullPath = [];
+  console.log(path)
+  for (let key of Object.keys(obj)) {
+    if (path === key) {
+      // We are the tail of the tree
+      fullPath.push(key);
+    } else {
+      const subKeys=path.split(`${key}.`);
+      if (subKeys.length > 1 && path.startsWith(`${key}.`)) {
+        // The key matches the path
+        fullPath.push(key);
+        fullPath = fullPath.concat(getArrayPath(obj[key], subKeys[1]));
+      }
+    }
+  }
+  return fullPath;
+}
+
 module.exports = {
   getArrayPrefix,
   sanitizeProperty,
   containsModifier,
+  getArrayPath
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Autogenerate READMEs' tables for Bitnami Helm Charts",
   "main": "index.js",
   "scripts": {

--- a/tests/expected-readme.md
+++ b/tests/expected-readme.md
@@ -176,9 +176,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |
 | `arrayEmptyModifier`                                  | Test empty array modifier                                                                                                      | `[]`         |
-| `key.with.dots`                                       | A key with dots and a value                                                                                                    | `aValue`     |
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/expected-readme.md
+++ b/tests/expected-readme.md
@@ -176,7 +176,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |
 | `arrayEmptyModifier`                                  | Test empty array modifier                                                                                                      | `[]`         |
-
+| `key.with.dots`                                       | A key with dots and a value                                                                                                    | `aValue`     |
+| `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
+| `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/test-readme.md
+++ b/tests/test-readme.md
@@ -176,6 +176,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |
 | `arrayEmptyModifier`                                  | Test empty array modifier                                                                                                      | `[]`         |
+| `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
+| `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -522,3 +522,12 @@ nullableArray: []
 
 ## @param arrayEmptyModifier [array] Test empty array modifier
 arrayEmptyModifier: value
+
+## @param annotations.prometheus.io/scrape A Prometheus annotation
+annotations:
+  prometheus.io/scrape: "true"
+## @param weird.key.with.weird.format/and.object A weird key with weird format and an object inside.
+weird.key:
+  with:
+    weird.format/and:
+      object: asValue


### PR DESCRIPTION
Signed-off-by: Miguel A. Cabrera Minagorri <mcabrera@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

**Description of the change**

This PR adds support for common K8s annotations and keys using dots and/or other characters combined.

It supports the rendering of that kind of parameter in the READMEs, but not in the schemas. This is because the schema generation needs some refactorization to support it.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #22 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [x] New features are documented in the README.md
- [x] New features contain a new test at the `tests` folder
- [x] All tests pass running `npm test`

