### PR TITLE
Use empty items when array types cannot be identified

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -157,9 +157,7 @@ function generateSchema(value, tree, properties, ignoreDefault = false) {
         // The last element of the tree is an array. It is a plain or empty array since if not, the tree would have more elements
         if (value.value == null || value.value.length === 0) {
           // When it is an empty array
-          properties[tree[i]].items = {
-            type: "", //TODO: how do we know the type in empty arrays?
-          };
+          properties[tree[i]].items = {}; //TODO: how do we know the type in empty arrays?
         } else {
           properties[tree[i]].items = { type: (typeof value.value[0]) };
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "readme-generator-for-helm",
-      "version": "2.1.0",
+      "version": "2.4.1",
       "license": "ISC",
       "dependencies": {
         "commander": "^7.1.0",
@@ -4828,9 +4828,9 @@
       "dev": true
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -4867,18 +4867,18 @@
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/kind-of": {
@@ -11299,9 +11299,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -11332,14 +11332,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-generator-for-helm",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Autogenerate READMEs' tables for Bitnami Helm Charts",
   "main": "index.js",
   "scripts": {

--- a/tests/expected-schema.json
+++ b/tests/expected-schema.json
@@ -14,9 +14,7 @@
                     "type": "array",
                     "description": "Global Docker registry secret names as an array",
                     "default": [],
-                    "items": {
-                        "type": ""
-                    }
+                    "items": {}
                 }
             }
         },
@@ -44,17 +42,13 @@
             "type": "array",
             "description": "Array of extra objects to deploy with the release",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "hostAliases": {
             "type": "array",
             "description": "Add deployment host aliases",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "image": {
             "type": "object",
@@ -83,9 +77,7 @@
                     "type": "array",
                     "description": "Specify docker-registry secret names as an array",
                     "default": [],
-                    "items": {
-                        "type": ""
-                    }
+                    "items": {}
                 }
             }
         },
@@ -323,17 +315,13 @@
             "type": "array",
             "description": "Override default container command (useful when using custom images)",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "args": {
             "type": "array",
             "description": "Override default container args (useful when using custom images)",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "extraEnvVars": {
             "type": "array",
@@ -524,9 +512,7 @@
                     "type": "array",
                     "description": "Node label values to match. Ignored if `affinity` is set",
                     "default": [],
-                    "items": {
-                        "type": ""
-                    }
+                    "items": {}
                 }
             }
         },
@@ -544,9 +530,7 @@
             "type": "array",
             "description": "Tolerations for pod assignment",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "podLabels": {
             "type": "object",
@@ -562,17 +546,13 @@
             "type": "array",
             "description": "Optionally specify extra list of additional volumes for Kubewatch pods",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "extraVolumeMounts": {
             "type": "array",
             "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "initContainers": {
             "type": "object",
@@ -766,9 +746,7 @@
             "description": "Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.",
             "default": null,
             "nullable": true,
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "nullableNullString": {
             "type": "string",
@@ -793,9 +771,7 @@
             "description": "Nullable parameter with an array value",
             "default": [],
             "nullable": true,
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "arrayEmptyModifier": {
             "type": "array",

--- a/tests/test-schema.json
+++ b/tests/test-schema.json
@@ -14,9 +14,7 @@
                     "type": "array",
                     "description": "Global Docker registry secret names as an array",
                     "default": [],
-                    "items": {
-                        "type": ""
-                    }
+                    "items": {}
                 }
             }
         },
@@ -44,17 +42,13 @@
             "type": "array",
             "description": "Array of extra objects to deploy with the release",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "hostAliases": {
             "type": "array",
             "description": "Add deployment host aliases",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "image": {
             "type": "object",
@@ -83,9 +77,7 @@
                     "type": "array",
                     "description": "Specify docker-registry secret names as an array",
                     "default": [],
-                    "items": {
-                        "type": ""
-                    }
+                    "items": {}
                 }
             }
         },
@@ -323,17 +315,13 @@
             "type": "array",
             "description": "Override default container command (useful when using custom images)",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "args": {
             "type": "array",
             "description": "Override default container args (useful when using custom images)",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "extraEnvVars": {
             "type": "array",
@@ -524,9 +512,7 @@
                     "type": "array",
                     "description": "Node label values to match. Ignored if `affinity` is set",
                     "default": [],
-                    "items": {
-                        "type": ""
-                    }
+                    "items": {}
                 }
             }
         },
@@ -544,9 +530,7 @@
             "type": "array",
             "description": "Tolerations for pod assignment",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "podLabels": {
             "type": "object",
@@ -562,17 +546,13 @@
             "type": "array",
             "description": "Optionally specify extra list of additional volumes for Kubewatch pods",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "extraVolumeMounts": {
             "type": "array",
             "description": "Optionally specify extra list of additional volumeMounts for Kubewatch container(s)",
             "default": [],
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "initContainers": {
             "type": "object",
@@ -766,9 +746,7 @@
             "description": "Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.",
             "default": null,
             "nullable": true,
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "nullableNullString": {
             "type": "string",
@@ -793,9 +771,7 @@
             "description": "Nullable parameter with an array value",
             "default": [],
             "nullable": true,
-            "items": {
-                "type": ""
-            }
+            "items": {}
         },
         "arrayEmptyModifier": {
             "type": "array",


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

Description of the change

This change removes the empty type for unknown array items in JSON schemas:
```json
"someProperty": {
    "type": "array",
    ...
    "items": {}
}
```

**Benefits**

Valid JSON schemas are generated.

**Possible drawbacks**

Empty items type might be there for some practical reason that is unknown to me, and this change might break some logic somewhere?

**Applicable issues**

* #42
* #34 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [ ] New features are documented in the README.md
- [X] New features contain a new test at the `tests` folder
- [X] All tests pass running `npm test`

