### PR TITLE
Pkg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ $ npm install -g pkg
 $ pkg . -o readme-generator-for-helm
 ```
 
-Depending on how you installed NodeJS in your system, you may need to modify your `PATH` environment variable to be able to execute the tool.
-
 ## Test
 
 We use [Jest](https://jestjs.io) to implement the tests. In order to test your changes, execute the following command:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ $ npm install ./readme-generator-for-helm
 
 Depending on how you installed NodeJS in your system, you may need to modify your `PATH` environment variable to be able to execute the tool.
 
+## Single Binary
+
+Execute the following commands to create a single executable binary for the tool:
+
+```console
+$ git clone https://github.com/bitnami-labs/readme-generator-for-helm
+$ cd ./readme-generator-for-helm
+$ npm install -g pkg
+$ pkg . -o readme-generator-for-helm
+```
+
+Depending on how you installed NodeJS in your system, you may need to modify your `PATH` environment variable to be able to execute the tool.
+
 ## Test
 
 We use [Jest](https://jestjs.io) to implement the tests. In order to test your changes, execute the following command:

--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
   "bugs": {
     "url": "https://github.com/bitnami-labs/readme-generator-for-helm/issues"
   },
-  "homepage": "https://github.com/bitnami-labs/readme-generator-for-helm#readme"
+  "homepage": "https://github.com/bitnami-labs/readme-generator-for-helm#readme",
+  "pkg": {
+    "assets": [
+        "config.json"
+    ]
+  }
 }


### PR DESCRIPTION
In order to be able to release this tool as a single binary executable without having to install node and npm, for example, if you want to use it within a docker image, the pkg module asks to specify the assets you need, the only one that is not added automatically is config.json.

I already built the binary and tested it in a clean debian docker image and it runs fine.