### PR TITLE
Clarified documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The table that will be inserted into the `readme.md` will have the following str
 ...
 ```
 
-The number of `#` characters needed for the section titles is dynamically calculated, and the title of the `Parameters` section can be configured via the [configuration file](#configuration-file). The `README.md` file with a `# Parameters` section must be created before running the tool.
+The number of `#` characters needed for the section titles is dynamically calculated, and the title of the `Parameters` section can be configured via the [configuration file](#configuration-file). The `README.md` file with a `## Parameters` section must be created before running the tool, the `Parameters` section should have two `#` or more symbols.
 
 ## Requirements
 


### PR DESCRIPTION
### Description of the change

This MR clarified the `README.md` documentation on the `# Parameters` requirement. Where the documentation previously stated that a `# Parameters` section is required, it now states that the `Parameters` section should include at least two `#` or more symbols. 

Change was made because `lib/render.js:74` only looks for section titles with at least two `##` symbols.

### Benefits

I ran into the error that my `# Parameters` section could not be found due to this, so fixing this in the documentation hopefully prevents others from running into the same problem!

### Checklist
- Removed all checks, since none are relevant for a `README.md` change without any code changes.

