### PR TITLE
docs: add particular use case to the modifiers docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,34 @@ Currently supported modifiers:
 
 The modifiers are also customizable via the [configuration file](#configuration-file).
 
+In case you are adding a `custom modifier` to a parameter that does not have value in the values file
+you must add one of the `supported modifiers` as last modifier.
+
+Example:
+
+Values file
+
+```yaml
+# @param noDefaultValue [number, nullable] Description
+# noDefaultValue: 1
+```
+
+Custom configuration snippet:
+
+```json
+{
+  ...
+    "modifiers": {
+    "array": "array",
+    "object": "object"
+    "string": "string"
+    "nullable": "nullable",
+    "number": "number"
+  },
+  ...
+}
+```
+
 ## Configuration file
 
 The configuration file has the following structure:

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -36,7 +36,7 @@ function applyModifiers(param, config) {
           // modifier specifies the default value.
           break;
         default:
-          throw new Error(`Unknown modifier: ${modifier}`);
+          throw new Error(`Unknown modifier: ${modifier} for patameter ${param.name}`);
       }
     });
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -36,7 +36,7 @@ function applyModifiers(param, config) {
           // modifier specifies the default value.
           break;
         default:
-          throw new Error(`Unknown modifier: ${modifier} for patameter ${param.name}`);
+          throw new Error(`Unknown modifier: ${modifier} for parameter ${param.name}`);
       }
     });
   }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

### Description of the change

It adds a particular case to the modifiers documentation I hit using custom modifiers. 
The use case is when you do not give any value to the parameter and use a custom modifier.
Also, it adds the name of the parameter that hits the error when an error related to modifiers happens.

### Benefits

Users will not spend time trying to resolve the issue, it is documented.

### Possible drawbacks

none
