### PR TITLE
fix(lib/utils.js): Change regexp to take only the 'key' at the beginning

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,7 +57,7 @@ function getArrayPath(obj, path, index = 0) {
         } else {
           // We are defining a capturing group to get the index number
           // if we are accesing to a particular array element
-          const keyRegex = new RegExp(`${key}(?:\\[(\\d+)\\])*\\.`);
+          const keyRegex = new RegExp(`^${key}(?:\\[(\\d+)\\])*\\.`);
           const subKeys = path.split(keyRegex);
           if (subKeys.length > 1 && path.startsWith(key)) {
             // The key matches the path

--- a/tests/expected-readme.config.md
+++ b/tests/expected-readme.config.md
@@ -191,6 +191,7 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/expected-readme.empty-section.md
+++ b/tests/expected-readme.empty-section.md
@@ -181,6 +181,7 @@ This description starts in a new line instead of the same line of description st
 | `arrayEmptyModifier`                                  | Test empty array modifier                                                                                                      | `[]`         |
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |
 
 ## Configuration and installation details
 

--- a/tests/expected-readme.first-execution.md
+++ b/tests/expected-readme.first-execution.md
@@ -153,3 +153,4 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |

--- a/tests/expected-readme.last-section-text-below.md
+++ b/tests/expected-readme.last-section-text-below.md
@@ -191,6 +191,7 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/expected-readme.last-section.md
+++ b/tests/expected-readme.last-section.md
@@ -191,3 +191,4 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |

--- a/tests/expected-readme.md
+++ b/tests/expected-readme.md
@@ -191,6 +191,7 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/test-readme.config.md
+++ b/tests/test-readme.config.md
@@ -191,6 +191,7 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/test-readme.last-section-text-below.md
+++ b/tests/test-readme.last-section-text-below.md
@@ -191,6 +191,7 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/test-readme.last-section.md
+++ b/tests/test-readme.last-section.md
@@ -191,3 +191,4 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |

--- a/tests/test-readme.md
+++ b/tests/test-readme.md
@@ -191,6 +191,7 @@ This description starts in a new line instead of the same line of description st
 | `annotations.prometheus.io/scrape`                    | A Prometheus annotation                                                                                                        | `true`       |
 | `weird.key.with.weird.format/and.object`              | A weird key with weird format and an object inside.                                                                            | `asValue`    |
 | `foo.file.ext.foo`                                    | A weird key with a list.                                                                                                       | `["bar"]`    |
+| `vault.annotations.vault.hashicorp.com/agent-inject`  | Some desc                                                                                                                      | `true`       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -552,3 +552,8 @@ foo:
   file.ext:
     foo:
       - bar
+## Issue: https://github.com/bitnami/readme-generator-for-helm/issues/70
+## @param vault.annotations.vault.hashicorp.com/agent-inject Some desc
+vault:
+  annotations:
+    vault.hashicorp.com/agent-inject: "true"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

### Description of the change

Change regexp to take only the 'key' at the beginning.

### Benefits

Other `keys` in the path won't be split/removed.

### Possible drawbacks

I've not detected any possible drawback.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #70

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

### Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [N/A] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [ ] New features are documented in the README.md
- [X] New features contain a new test at the `tests` folder
- [X] All tests pass running `npm test`
