### PR TITLE
Fix node:22 bitnami to leagcy repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM bitnami/node:22
+FROM bitnamilegacy/node:22
 
 LABEL org.opencontainers.image.authors="https://bitnami.com/contact" \
       org.opencontainers.image.description="Readme Generator For Helm" \


### PR DESCRIPTION
Due to the latest bitnami changes in the https://hub.docker.com/r/bitnami/node it seems that this docker image is under the bitnami legacy repository now https://hub.docker.com/layers/bitnamilegacy/node/22